### PR TITLE
Fix correctness issues in conTestD and bootstrapD

### DIFF
--- a/R/conTestD.R
+++ b/R/conTestD.R
@@ -6,11 +6,11 @@ conTestD <- function(model = NULL, data = NULL, constraints = NULL,
                      parallel = c("no", "multicore", "snow"), 
                      ncpus = 1L, cl = NULL, verbose = FALSE, ...) {
 
+  stopifnot(!is.null(constraints), all(type %in% c("A", "B")))
+
   # fit unrestricted model
   fit.h2 <- sem(model, ..., data = data, test = "standard") #se = "none"
-  
-  stopifnot(!is.null(constraints))
-  
+
   ## fit null-model
   # add constraints to parameter table
   CON <- attr(lavParseModelString(constraints), "constraints")
@@ -27,12 +27,13 @@ conTestD <- function(model = NULL, data = NULL, constraints = NULL,
       this.op  <- CON[[con]]$op
       this.rhs <- CON[[con]]$rhs
       
-      # find this line in user.equal@ParTable
-      idx <- which(user.equal$lhs == this.lhs,
-                   user.equal$op  == this.op,
+      # find this line in user.equal
+      idx <- which(user.equal$lhs == this.lhs &
+                   user.equal$op  == this.op &
                    user.equal$rhs == this.rhs)
-      if (length(idx) == 0L) { # not found, give warning?
-        stop("lavaan ERROR: no inequality constraints (<, >) found.")
+      if (length(idx) == 0L) {
+        stop("restriktor ERROR: constraint ", this.lhs, " ", this.op, " ",
+             this.rhs, " not found in the parameter table.")
       }
       
       # change operator to ==
@@ -68,8 +69,8 @@ conTestD <- function(model = NULL, data = NULL, constraints = NULL,
   output <- list(fit.h0 = fit.h0, fit.h2 = fit.h2,
                  double.bootstrap = double.bootstrap, 
                  double.bootstrap.alpha = double.bootstrap.alpha, 
-                 return.test = return.test, 
-                 type = bootstrap.type)
+                 return.test = return.test,
+                 bootstrap.type = bootstrap.type)
   
   if ("A" %in% type) {
     output$bootA <- bootA

--- a/R/conTest_print.R
+++ b/R/conTest_print.R
@@ -257,7 +257,7 @@ print.conTestLavaan <- function(x, digits = max(3, getOption("digits") - 2), ...
   cat("  Total sample size               :", sum(unlist(object$fit.h2@Data@norig)), "\n\n")
   cat("  Estimator                       :", object$fit.h2@Options$estimator, "\n")
   cat("  Missing data                    :", object$fit.h2@Options$missing, "\n")
-  cat("  Bootstrap method                :", object$type, "\n")
+  cat("  Bootstrap method                :", object$bootstrap.type, "\n")
   cat("  Double bootstrap method         :", object$double.bootstrap, "\n")
   
   dbtype <- object$double.bootstrap

--- a/R/con_bootstrapD.R
+++ b/R/con_bootstrapD.R
@@ -7,11 +7,12 @@ bootstrapD <- function(h0 = NULL, h1 = NULL, constraints, type = "A",
                        seed = NULL) {
   
   bootstrap.type <- tolower(bootstrap.type)
-  stopifnot(inherits(h1, "lavaan"), 
-            bootstrap.type %in% c("bollen.stine", "parametric", 
-                                  "yuan", "nonparametric", "ordinary"), 
+  stopifnot(inherits(h0, "lavaan"),
+            inherits(h1, "lavaan"),
+            bootstrap.type %in% c("bollen.stine", "parametric",
+                                  "yuan", "nonparametric", "ordinary"),
             double.bootstrap %in% c("no", "FDB", "standard"),
-            type %in% c("A", "B"))
+            length(type) == 1L, type %in% c("A", "B"))
   
   if (bootstrap.type == "nonparametric") {
     bootstrap.type <- "ordinary"
@@ -20,22 +21,19 @@ bootstrapD <- function(h0 = NULL, h1 = NULL, constraints, type = "A",
     stop("lavaan ERROR: this function is not (yet) available if conditional.x = TRUE")
   }
   
-  old_options <- options()
-  on.exit(options(old_options))
-  options(warn = warn)
-  
   D <- rep(as.numeric(NA), R)
-  
+
   if (double.bootstrap == "FDB") {
     D.2 <- numeric(R)
   }
   else if (double.bootstrap == "standard") {
     plugin.pvalues <- numeric(R)
   }
-  if (missing(parallel)) 
+  if (missing(parallel)) {
     parallel <- "no"
-    parallel <- match.arg(parallel)
-    have_mc <- have_snow <- FALSE
+  }
+  parallel <- match.arg(parallel)
+  have_mc <- have_snow <- FALSE
   if (parallel != "no" && ncpus > 1L) {
     if (parallel == "multicore") 
       have_mc <- .Platform$OS.type != "windows"
@@ -123,8 +121,14 @@ bootstrapD <- function(h0 = NULL, h1 = NULL, constraints, type = "A",
   ## compute original D value
   # create constraint matrix based on the character string containing the constraints.
   parTable <- as.list(parTable(h1)) 
-  conInfo  <- lav_constraints_parse(parTable, constraints = constraints, 
+  conInfo  <- lav_constraints_parse(parTable, constraints = constraints,
                                             theta = lavaan::coef(h1))
+  if (isTRUE(conInfo$ceq.nonlinear.flag) || isTRUE(conInfo$cin.nonlinear.flag)) {
+    warning("restriktor WARNING: nonlinear constraints detected. The ",
+            "constraints are linearized around the original parameter ",
+            "estimates and this linearization is reused in all bootstrap ",
+            "draws; results may be inaccurate.")
+  }
   # equality constraints
   Amat.ceq <- conInfo$ceq.JAC
   # inequality constraints
@@ -141,32 +145,36 @@ bootstrapD <- function(h0 = NULL, h1 = NULL, constraints, type = "A",
   I.hat <- lavInspect(h1, "information")
   N <- lavaan::nobs(h1) 
   
-  if ("A" %in% type) {
+  if (type == "A") {
   ## hypothesis test Type A
   # fit equality constraint model.
     out.eq <- solve.QP(Dmat = I.hat, dvec = theta.hat %*% I.hat, Amat = t(Amat),
                        bvec = rhs, meq = nrow(Amat))
-    # fit inequality constraint model, some equality constraints may be preserved.
+    # fit inequality constraint model, equality constraints are preserved.
     out.ineq <- solve.QP(Dmat = I.hat, dvec = theta.hat %*% I.hat, Amat = t(Amat),
-                         bvec = rhs, meq = nrow(Amat.ceq)) 
-    
+                         bvec = rhs, meq = nrow(Amat.ceq))
+
     D.original <- N * 2 * (out.eq$value - out.ineq$value)
-  }
-  
-  if ("B" %in% type) {
+  } else {
   ## hypothesis test Type B
-    # fit inequality constraint model, some equality constraints may be preserved.
+    # fit inequality constraint model, equality constraints are preserved.
     out.ineq <- solve.QP(Dmat = I.hat, dvec = theta.hat %*% I.hat, Amat = t(Amat),
-                         bvec = rhs, meq = nrow(Amat.ceq)) 
-    
-    # fit unconstraint model, some equality constraints may be preserved.         FIXME
-    out.un <- solve.QP(Dmat = I.hat, dvec = theta.hat %*% I.hat, 
-                       Amat = t(matrix(0, nrow = dim(Amat)[1], ncol = dim(Amat)[2])),
-                       bvec = rep(0, length(rhs)), meq = 0)
-    
-    D.original <- N * 2 * (out.ineq$value - out.un$value)
+                         bvec = rhs, meq = nrow(Amat.ceq))
+
+    # fit unconstrained model, equality constraints are preserved.
+    if (nrow(Amat.ceq) > 0L) {
+      out.un <- solve.QP(Dmat = I.hat, dvec = theta.hat %*% I.hat,
+                         Amat = t(Amat.ceq), bvec = rhs.ceq,
+                         meq = nrow(Amat.ceq))
+      value.un <- out.un$value
+    } else {
+      # without any constraints the minimum lies at theta.hat
+      value.un <- -0.5 * c(theta.hat %*% I.hat %*% theta.hat)
+    }
+
+    D.original <- N * 2 * (out.ineq$value - value.un)
   }
-  
+
   
   fn <- function(b) {
     if (bootstrap.type == "bollen.stine" || bootstrap.type == "ordinary" || 
@@ -253,33 +261,44 @@ bootstrapD <- function(h0 = NULL, h1 = NULL, constraints, type = "A",
     I.hat.boot <- lavInspect(fit.boot.h1, "information")
     
 
-    if ("A" %in% type) {
-    # hypothesis test Type A
-      out.eq.boot   <- solve.QP(Dmat = I.hat.boot, dvec = theta.hat.boot %*% I.hat.boot, Amat = t(Amat),
-                                bvec = rhs, meq = nrow(Amat))
-      out.ineq.boot <- solve.QP(Dmat = I.hat.boot, dvec = theta.hat.boot %*% I.hat.boot, Amat = t(Amat),
-                                bvec = rhs, meq = nrow(Amat.ceq))
-      
-      D.boot <- N * 2 * (out.eq.boot$value - out.ineq.boot$value)
+    D.boot <- try({
+      if (type == "A") {
+      # hypothesis test Type A
+        out.eq.boot   <- solve.QP(Dmat = I.hat.boot, dvec = theta.hat.boot %*% I.hat.boot, Amat = t(Amat),
+                                  bvec = rhs, meq = nrow(Amat))
+        out.ineq.boot <- solve.QP(Dmat = I.hat.boot, dvec = theta.hat.boot %*% I.hat.boot, Amat = t(Amat),
+                                  bvec = rhs, meq = nrow(Amat.ceq))
+
+        N * 2 * (out.eq.boot$value - out.ineq.boot$value)
+      } else {
+        # hypothesis test Type B
+        out.ineq.boot <- solve.QP(Dmat = I.hat.boot, dvec = theta.hat.boot %*% I.hat.boot, Amat = t(Amat),
+                                  bvec = rhs, meq = nrow(Amat.ceq))
+        # unconstrained model, equality constraints are preserved.
+        if (nrow(Amat.ceq) > 0L) {
+          out.un.boot <- solve.QP(Dmat = I.hat.boot, dvec = theta.hat.boot %*% I.hat.boot,
+                                  Amat = t(Amat.ceq), bvec = rhs.ceq,
+                                  meq = nrow(Amat.ceq))
+          value.un.boot <- out.un.boot$value
+        } else {
+          value.un.boot <- -0.5 * c(theta.hat.boot %*% I.hat.boot %*% theta.hat.boot)
+        }
+
+        N * 2 * (out.ineq.boot$value - value.un.boot)
+      }
+    }, silent = TRUE)
+    if (inherits(D.boot, "try-error")) {
+      if (verbose)
+        cat("     FAILED: solve.QP\n")
+      return(NULL)
     }
-    
-    if ("B" %in% type) {
-      # hypothesis test Type B
-      out.ineq.boot <- solve.QP(Dmat = I.hat.boot, dvec = theta.hat.boot %*% I.hat.boot, Amat = t(Amat),
-                                bvec = rhs, meq = nrow(Amat.ceq))
-      out.un.boot <- solve.QP(Dmat = I.hat.boot, dvec = theta.hat.boot %*% I.hat.boot, 
-                              Amat = t(matrix(0, nrow = dim(Amat)[1], ncol = dim(Amat)[2])),
-                              bvec = rep(0, length(rhs)), meq = 0)
-      
-      D.boot <- N * 2 * (out.ineq.boot$value - out.un.boot$value)
-    }
-    
-    
+
+
     if (double.bootstrap == "standard") {
       if (verbose)
         cat("  ... ... calibrating p.value - ")
       plugin.pvalue <- bootstrapD(h0 = fit.boot.h0, h1 = fit.boot.h1,
-                                  constraints = constraints,
+                                  constraints = constraints, type = type,
                                   R = double.bootstrap.R,
                                   bootstrap.type = bootstrap.type, verbose = FALSE,
                                   return.D = FALSE,
@@ -290,8 +309,8 @@ bootstrapD <- function(h0 = NULL, h1 = NULL, constraints, type = "A",
       attr(D.boot, "plugin.pvalue") <- plugin.pvalue
     } else if (double.bootstrap == "FDB") {
       plugin.pvalue <- bootstrapD(h0 = fit.boot.h0, h1 = fit.boot.h1,
-                                  constraints = constraints,
-                                  R = 1L, bootstrap.type = bootstrap.type, 
+                                  constraints = constraints, type = type,
+                                  R = 1L, bootstrap.type = bootstrap.type,
                                   verbose = FALSE, warn = warn,
                                   return.D = TRUE, parallel = parallel, ncpus = ncpus,
                                   cl = cl, double.bootstrap = "no")
@@ -305,6 +324,13 @@ bootstrapD <- function(h0 = NULL, h1 = NULL, constraints, type = "A",
   
   
   
+  if (!is.null(seed))
+    set.seed(seed)
+
+  old_options <- options()
+  on.exit(options(old_options))
+  options(warn = warn)
+
   RR <- sum(R)
   res <- if (ncpus > 1L && (have_mc || have_snow)) {
     if (have_mc) {
@@ -340,14 +366,14 @@ bootstrapD <- function(h0 = NULL, h1 = NULL, constraints, type = "A",
     }
   }
   if (length(error.idx) > 0L) {
-    warning("lavaan WARNING: only ", (R - length(error.idx)), 
+    warning("restriktor WARNING: only ", (RR - length(error.idx)),
             " bootstrap draws were successful")
     D <- D[-error.idx]
-    if (length(D) == 0) 
+    if (length(D) == 0)
       D <- as.numeric(NA)
+    attr(D, "error.idx") <- error.idx
     if (double.bootstrap == "standard") {
       plugin.pvalues <- plugin.pvalues[-error.idx]
-      attr(D, "error.idx") <- error.idx
     }
     if (double.bootstrap == "FDB") {
       D.2 <- D.2[-error.idx]
@@ -356,35 +382,42 @@ bootstrapD <- function(h0 = NULL, h1 = NULL, constraints, type = "A",
   }
   else {
     if (verbose) {
-      cat("Number of successful bootstrap draws:", 
-          (R - length(error.idx)), "\n")
+      cat("Number of successful bootstrap draws:",
+          (RR - length(error.idx)), "\n")
     }
   }
-  pvalue <- sum(D > D.original) / length(D)
+
+  if (all(is.na(D))) {
+    warning("restriktor WARNING: no successful bootstrap draws; ",
+            "p-value cannot be computed.")
+    pvalue <- as.numeric(NA)
+  } else {
+    # smoothed bootstrap p-value (Davison & Hinkley, 1997, eq. 4.12)
+    pvalue <- (1 + sum(D >= D.original)) / (1 + length(D))
+  }
+
+  attr(pvalue, "D.original") <- D.original
   if (return.D) {
-    attr(pvalue, "D.original") <- D.original
     attr(pvalue, "D") <- D
   }
-  if (double.bootstrap == "FDB") {
+  if (double.bootstrap == "FDB" && !is.na(pvalue)) {
     Q <- (1 - pvalue)
     d.q <- quantile(D.2, Q, na.rm = TRUE)
-    adj.pvalue <- sum(D > d.q)/length(D)
+    adj.pvalue <- (1 + sum(D >= d.q)) / (1 + length(D))
     attr(pvalue, "D.q") <- d.q
     attr(pvalue, "adj.pvalue") <- adj.pvalue
     if (return.D) {
-      attr(pvalue, "D.original") <- D.original
-      attr(pvalue, "D") <- D
       attr(pvalue, "D2") <- D.2
     }
-  } else if (double.bootstrap == "standard") {
-    adj.alpha <- quantile(plugin.pvalues, double.bootstrap.alpha, 
+  } else if (double.bootstrap == "standard" && !is.na(pvalue)) {
+    adj.alpha <- quantile(plugin.pvalues, double.bootstrap.alpha,
                           na.rm = TRUE)
     attr(pvalue, "adj.alpha") <- adj.alpha
     adj.pvalue <- sum(plugin.pvalues < pvalue)/length(plugin.pvalues)
     attr(pvalue, "plugin.pvalues") <- plugin.pvalues
     attr(pvalue, "adj.pvalue") <- adj.pvalue
   }
-  
+
   attr(pvalue, "Amat") <- Amat
   pvalue
 }

--- a/man/bootstrapD.Rd
+++ b/man/bootstrapD.Rd
@@ -28,9 +28,9 @@
   \item{R}{Integer. The number of bootstrap draws.}
   \item{return.D}{Logical; if \code{TRUE}, the function returns bootstrapped         
     D-values.}
-  \item{double.bootstrap}{If \code{"standard"} (default) the genuine double bootstrap is 
-    used to compute an additional set of plug-in p-values for each bootstrap       
-    sample. If \code{"no"}, no double bootstrap is used. If \code{"FDB"}, 
+  \item{double.bootstrap}{If \code{"standard"} the genuine double bootstrap is
+    used to compute an additional set of plug-in p-values for each bootstrap
+    sample. If \code{"no"} (default), no double bootstrap is used. If \code{"FDB"},
     the fast double bootstrap is used to compute second level LRT-values for 
     each bootstrap sample. Note that the \code{"FDB"} is experimental and should 
     not be used by inexperienced users.}    
@@ -71,7 +71,9 @@
 }
 
 \value{
- A bootstrap p value, calculated as the proportion of bootstrap samples with a D statistic at least as large as the D statistic for the original data.
+ A bootstrap p value, calculated as \eqn{(1 + s) / (1 + R)}, where \eqn{s} is
+ the number of successful bootstrap samples with a D statistic at least as
+ large as the D statistic for the original data.
 }
 
 \examples{

--- a/tests/testthat/test-conTestD.R
+++ b/tests/testthat/test-conTestD.R
@@ -114,7 +114,7 @@ test_that("conTestD: output bevat verwachte velden", {
   expect_true(!is.null(result$double.bootstrap))
   expect_true(!is.null(result$double.bootstrap.alpha))
   expect_true(!is.null(result$return.test))
-  expect_true(!is.null(result$type))
+  expect_true(!is.null(result$bootstrap.type))
 })
 
 test_that("conTestD: print methode werkt", {
@@ -154,7 +154,7 @@ test_that("conTestD: fout bij ongeldig model", {
   expect_error(
     conTestD(model = "invalid_model_syntax ~~~", data = df_path,
              constraints = "a > 0"),
-    "lavaan|syntax|ERROR"
+    "lavaan|syntax|ERROR|unexpected"
   )
 })
 


### PR DESCRIPTION
conTestD:
- Fix broken which() call when converting inequality constraints to equalities: the op and rhs conditions were passed as the arr.ind and useNames arguments of which() and silently ignored, so all partable rows with a matching lhs were converted. Combine the conditions with & instead.
- Validate constraints and type up front; clearer error message when a constraint is not found in the parameter table.
- Rename the output field 'type' to 'bootstrap.type' to avoid confusion with the hypothesis test type (print method and test updated).

bootstrapD:
- Pass 'type' through to the inner double-bootstrap calls (standard and FDB); previously the inner bootstrap always fell back to type A, so calibrated p-values for type B tests were computed with the wrong statistic.
- Type B: preserve equality constraints in the 'unconstrained' model instead of dropping all constraints (resolves FIXME); without equality constraints the unconstrained minimum is theta.hat itself.
- Reject vector 'type' (a second element used to silently overwrite the type A statistic) and require h0 to be a lavaan object.
- Wrap the solve.QP calls inside the bootstrap function in try() so a numerically singular information matrix marks the draw as failed instead of aborting the whole bootstrap.
- Honor the 'seed' argument for serial and multicore execution.
- Warn when nonlinear constraints are detected, since the constraint matrix is linearized once at the original estimates and reused across draws; emit the warning before options(warn) is lowered.
- Use the smoothed bootstrap p-value (1 + sum(D >= D.original)) / (1 + R) and warn explicitly when no draws succeed instead of silently returning NA arithmetic.
- Always attach D.original so print.conTestLavaan also works with return.test = FALSE; fix misleading indentation in the parallel set-up; always record error.idx on D.

Docs: correct the double.bootstrap default in bootstrapD.Rd and document the smoothed p-value formula.


Claude-Session: https://claude.ai/code/session_01CvkQ6FLAMKGoqkgE5ZscZC