### PR TITLE
use penalty_factor in evSyn and leave1studyout

### DIFF
--- a/R/goric_evSyn.R
+++ b/R/goric_evSyn.R
@@ -160,13 +160,20 @@ evSyn <- function(object, input_type = NULL, ...) {
 # GORIC(A) evidence synthesis based on the (standardized) parameter estimates and 
 # the covariance matrix
 evSyn_est <- function(object, ..., VCOV = list(), hypotheses = list(),
-                      type_ev = c("added", "equal", "average"), 
+                      type_ev = c("added", "equal", "average"),
                       comparison = c("unconstrained", "complement", "none"),
                       hypo_names = c(),
                       type = c("gorica", "goricac"),
                       order_studies = c("input_order", "ascending", "descending"),
                       study_names = c(),
-                      study_sample_nobs = NULL) {
+                      study_sample_nobs = NULL,
+                      penalty_factor = 2) {
+
+  if (!is.numeric(penalty_factor) || length(penalty_factor) != 1L ||
+      is.na(penalty_factor) || penalty_factor < 0) {
+    stop("restriktor ERROR: penalty_factor must be a single non-negative numeric value.",
+         call. = FALSE)
+  }
   
   if (missing(comparison)) {
     if (length(hypotheses) == 1) {
@@ -389,6 +396,7 @@ evSyn_est <- function(object, ..., VCOV = list(), hypotheses = list(),
                        hypotheses = hypotheses[[s]],
                        type = type, comparison = comparison,
                        sample_nobs = study_sample_nobs[s],
+                       penalty_factor = penalty_factor,
                        ...)
     
     if (comparison == "unconstrained") {
@@ -420,15 +428,15 @@ evSyn_est <- function(object, ..., VCOV = list(), hypotheses = list(),
     # Determine what the overall preferred hypothesis is.
     if (type_ev == "added") { 
       # added-evidence approach
-      OverallGoric <- colSums(-LL_m) + colSums(PT)
+      OverallGoric <- -2 * colSums(LL_m) + penalty_factor * colSums(PT)
       OverallPrefHypo <- which(OverallGoric == min(OverallGoric))
     } else if (type_ev == "equal") { 
       # equal-evidence approach
-      OverallGoric <- colSums(-LL_m) + colMeans(PT)
+      OverallGoric <- -2 * colSums(LL_m) + penalty_factor * colMeans(PT)
       OverallPrefHypo <- which(OverallGoric == min(OverallGoric))
     } else if (type_ev == "average") { 
       # average-evidence approach
-      OverallGoric <- colMeans(-LL_m) + colMeans(PT)
+      OverallGoric <- -2 * colMeans(LL_m) + penalty_factor * colMeans(PT)
       OverallPrefHypo <- which(OverallGoric == min(OverallGoric))
     } #else {}
     if (order_studies == "descending") {
@@ -475,7 +483,7 @@ evSyn_est <- function(object, ..., VCOV = list(), hypotheses = list(),
     for(s in 1:S) {
       sumLL <- sumLL + LL_m[s, ]
       sumPT <- sumPT + PT[s, ]
-      CumulativeGorica[s,] <- -2 * sumLL + 2 * sumPT
+      CumulativeGorica[s,] <- -2 * sumLL + penalty_factor * sumPT
       minGoric <- min(CumulativeGorica[s, ])
       CumulativeGoricaWeights[s, ] <- exp(-0.5*(CumulativeGorica[s, ]-minGoric)) / 
         sum(exp(-0.5*(CumulativeGorica[s, ]-minGoric)))
@@ -485,7 +493,7 @@ evSyn_est <- function(object, ..., VCOV = list(), hypotheses = list(),
     for(s in 1:S) {
       sumLL <- sumLL + LL_m[s, ]
       sumPT <- sumPT + PT[s, ]
-      CumulativeGorica[s,] <- -2 * sumLL + 2 * sumPT/s
+      CumulativeGorica[s,] <- -2 * sumLL + penalty_factor * sumPT/s
       minGoric <- min(CumulativeGorica[s, ])
       CumulativeGoricaWeights[s, ] <- exp(-0.5*(CumulativeGorica[s, ]-minGoric)) / 
         sum(exp(-0.5*(CumulativeGorica[s, ]-minGoric)))
@@ -495,7 +503,7 @@ evSyn_est <- function(object, ..., VCOV = list(), hypotheses = list(),
     for(s in 1:S) {
       sumLL <- sumLL + LL_m[s, ]
       sumPT <- sumPT + PT[s, ]
-      CumulativeGorica[s,] <- -2 * sumLL/s + 2 * sumPT/s
+      CumulativeGorica[s,] <- -2 * sumLL/s + penalty_factor * sumPT/s
       minGoric <- min(CumulativeGorica[s, ])
       CumulativeGoricaWeights[s, ] <- exp(-0.5*(CumulativeGorica[s, ]-minGoric)) / 
         sum(exp(-0.5*(CumulativeGorica[s, ]-minGoric)))
@@ -556,6 +564,7 @@ evSyn_est <- function(object, ..., VCOV = list(), hypotheses = list(),
               order_studies = orderStudies,
               study_names = study_names,
               study_sample_nobs = study_sample_nobs,
+              penalty_factor = penalty_factor,
               PT_m = PT,
               GORICA_weight_m = GORICA_weight_m, 
               LL_weights_m = LL_weights_m,
@@ -579,14 +588,21 @@ evSyn_est <- function(object, ..., VCOV = list(), hypotheses = list(),
 
 # -------------------------------------------------------------------------
 # GORIC(A) evidence synthesis based on log likelihood and penalty values
-evSyn_LL <- function(object, ..., PT = list(), 
+evSyn_LL <- function(object, ..., PT = list(),
                      type_ev = c("added", "equal", "average"),
                      hypo_names = c(),
                      type = c("goric", "goricc", "gorica", "goricac"),
                      order_studies = c("input_order", "ascending", "descending"),
-                     study_names = c()) {
-  
-  if (missing(type_ev)) 
+                     study_names = c(),
+                     penalty_factor = 2) {
+
+  if (!is.numeric(penalty_factor) || length(penalty_factor) != 1L ||
+      is.na(penalty_factor) || penalty_factor < 0) {
+    stop("restriktor ERROR: penalty_factor must be a single non-negative numeric value.",
+         call. = FALSE)
+  }
+
+  if (missing(type_ev))
     type_ev <- "added"
   type_ev <- match.arg(type_ev)
   
@@ -616,7 +632,7 @@ evSyn_LL <- function(object, ..., PT = list(),
   
   LL_m <- do.call(rbind, LL_m)
   PT <- do.call(rbind, PT)
-  IC <- -2 * LL_m + 2 * PT
+  IC <- -2 * LL_m + penalty_factor * PT
   #
   GORICA_weight_m <- matrix(NA, nrow = S, ncol = (NrHypos + 1))
   for(s in 1:S) {
@@ -639,15 +655,15 @@ evSyn_LL <- function(object, ..., PT = list(),
     # Determine what the overall preferred hypothesis is.
     if (type_ev == "added") { 
       # added-evidence approach
-      OverallGoric <- colSums(-LL_m) + colSums(PT)
+      OverallGoric <- -2 * colSums(LL_m) + penalty_factor * colSums(PT)
       OverallPrefHypo <- which(OverallGoric == min(OverallGoric))
     } else if (type_ev == "equal") { 
       # equal-evidence approach
-      OverallGoric <- colSums(-LL_m) + colMeans(PT)
+      OverallGoric <- -2 * colSums(LL_m) + penalty_factor * colMeans(PT)
       OverallPrefHypo <- which(OverallGoric == min(OverallGoric))
     } else if (type_ev == "average") { 
       # average-evidence approach
-      OverallGoric <- colMeans(-LL_m) + colMeans(PT)
+      OverallGoric <- -2 * colMeans(LL_m) + penalty_factor * colMeans(PT)
       OverallPrefHypo <- which(OverallGoric == min(OverallGoric))
     } # else {}
     if (order_studies == "descending") {
@@ -722,7 +738,7 @@ evSyn_LL <- function(object, ..., PT = list(),
     for(s in 1:S) {
       sumLL <- sumLL + LL_m[s, ]
       sumPT <- sumPT + PT[s, ]
-      CumulativeGorica[s, ] <- -2 * sumLL + 2 * sumPT
+      CumulativeGorica[s, ] <- -2 * sumLL + penalty_factor * sumPT
       minGoric <- min(CumulativeGorica[s, ])
       CumulativeGoricaWeights[s, ] <- exp(-0.5*(CumulativeGorica[s, ]-minGoric)) / 
         sum(exp(-0.5*(CumulativeGorica[s, ]-minGoric)))
@@ -732,7 +748,7 @@ evSyn_LL <- function(object, ..., PT = list(),
     for (s in 1:S) {
       sumLL <- sumLL + LL_m[s, ]
       sumPT <- sumPT + PT[s, ]
-      CumulativeGorica[s, ] <- -2 * sumLL + 2 * sumPT/s
+      CumulativeGorica[s, ] <- -2 * sumLL + penalty_factor * sumPT/s
       minGoric <- min(CumulativeGorica[s, ])
       CumulativeGoricaWeights[s, ] <- exp(-0.5*(CumulativeGorica[s, ]-minGoric)) / 
         sum(exp(-0.5*(CumulativeGorica[s, ]-minGoric)))
@@ -742,7 +758,7 @@ evSyn_LL <- function(object, ..., PT = list(),
     for (s in 1:S) {
       sumLL <- sumLL + LL_m[s, ]
       sumPT <- sumPT + PT[s, ]
-      CumulativeGorica[s, ] <- -2 * sumLL/s + 2 * sumPT/s
+      CumulativeGorica[s, ] <- -2 * sumLL/s + penalty_factor * sumPT/s
       minGoric <- min(CumulativeGorica[s, ])
       CumulativeGoricaWeights[s, ] <- exp(-0.5*(CumulativeGorica[s, ]-minGoric)) / 
         sum(exp(-0.5*(CumulativeGorica[s, ]-minGoric)))
@@ -769,7 +785,8 @@ evSyn_LL <- function(object, ..., PT = list(),
     order_studies = orderStudies,
     study_names = study_names,
     #study_sample_nobs = study_sample_nobs,
-    PT_m = PT, 
+    penalty_factor = penalty_factor,
+    PT_m = PT,
     GORICA_weight_m = GORICA_weight_m,
     LL_weights_m = LL_weights_m,
     GORICA_m = IC, 
@@ -1236,7 +1253,18 @@ evSyn_gorica <- function(object, ..., type_ev = c("added", "equal", "average"),
   }
   # TO DO als small sample, dan ook sample_nobs nodig of kan het zonder?
   # TO DO check of in elke zelfde aantal hypotheses (met evt controle of failsafe ook - dit als message dan), anders werkt het ook niet
-  
+
+  # Check if all objects use the same penalty factor; it is needed to aggregate
+  # the study-specific LL and PT values consistently with the study-specific ICs.
+  object_pfs <- vapply(object, function(x) {
+    if (is.null(x$penalty_factor)) 2 else x$penalty_factor
+  }, numeric(1))
+  if (length(unique(object_pfs)) > 1) {
+    stop("\nrestriktor ERROR: All goric objects must use the same penalty_factor. Found: ",
+         paste(unique(object_pfs), collapse = ", "), ".",
+         call. = FALSE)
+  }
+
   # Create a list for the evSyn_LL.list function
   conList <- list(
     type = object[[1]]$type,
@@ -1245,11 +1273,21 @@ evSyn_gorica <- function(object, ..., type_ev = c("added", "equal", "average"),
     type_ev = type_ev,
     hypo_names = hypo_names,
     order_studies = order_studies,
-    study_names = study_names
+    study_names = study_names,
+    penalty_factor = object_pfs[1]
   )
-  
+
+  # The penalty factor stored in the goric objects is authoritative.
+  dots <- list(...)
+  if (!is.null(dots$penalty_factor) && dots$penalty_factor != object_pfs[1]) {
+    message("\nrestriktor Message: The 'penalty_factor' argument is ignored; ",
+            "the penalty factor stored in the goric objects (", object_pfs[1],
+            ") is used.")
+  }
+  dots$penalty_factor <- NULL
+
   # Call the evSyn_LL.list function and return the result
-  result <- do.call(evSyn_LL, append(conList, list(...)))
+  result <- do.call(evSyn_LL, append(conList, dots))
   # Add the type from the goric objects (evSyn_LL does not carry type)
   result$type <- object[[1]]$type
   class(result) <- c(class(result), "evSyn_gorica")

--- a/R/goric_evSyn_leave1studyout.R
+++ b/R/goric_evSyn_leave1studyout.R
@@ -62,9 +62,17 @@ leave1studyout.evSyn <- function(object, ...) {
   if (type_ev == "equal") {
     LL_m <- object$LL_m
     PT_m <- object$PT_m
-    
+
     if (is.null(LL_m) || is.null(PT_m)) {
       stop("restriktor ERROR: LL_m and PT_m are required for type_ev = 'equal'.")
+    }
+
+    # Use the same penalty factor as in the original evSyn call, so that the
+    # leave-one-out ICs are consistent with the study-specific ICs.
+    # Default to 2 for (older) evSyn objects that do not store it.
+    penalty_factor <- object$penalty_factor
+    if (is.null(penalty_factor)) {
+      penalty_factor <- 2
     }
   }
   
@@ -111,14 +119,13 @@ leave1studyout.evSyn <- function(object, ...) {
     
     keep <- seq_len(S) != s
     
-    # Evt moet hier dan ook nog penalty_factor in verwerlt worden:
-    # -2 * colSums(LL_m[keep,]) + penalty_factor * colMeans(PT_m[keep,])  
-    # Of hebben we die term alleen in goric() ms
-    
+    # For "added" and "average" the IC values already contain the penalty
+    # factor used per study; only "equal" recombines LL and PT and thus needs
+    # the penalty factor explicitly.
     OverallGoric[s, ] <- switch(
       type_ev,
       added   = colSums(IC_m[keep, , drop = FALSE]),
-      equal   = -2 * colSums(LL_m[keep, , drop = FALSE]) + 2 * colMeans(PT_m[keep, , drop = FALSE]),
+      equal   = -2 * colSums(LL_m[keep, , drop = FALSE]) + penalty_factor * colMeans(PT_m[keep, , drop = FALSE]),
       average = colMeans(IC_m[keep, , drop = FALSE])
     )
     

--- a/man/evSyn.Rd
+++ b/man/evSyn.Rd
@@ -35,17 +35,17 @@ evSyn(object, input_type = NULL, \ldots)
 
 # input: Parameter estimates and covariance matrix
 evSyn_est(object, \ldots, VCOV = list(), hypotheses = list(),
-          type_ev = c("added", "equal", "average"), 
+          type_ev = c("added", "equal", "average"),
           comparison = c("unconstrained", "complement", "none"),
-          hypo_names = c(), type = c("gorica", "goricac"), 
+          hypo_names = c(), type = c("gorica", "goricac"),
           order_studies = c("input_order", "ascending", "descending"),
-          study_names = c(), study_sample_nobs = NULL)
+          study_names = c(), study_sample_nobs = NULL, penalty_factor = 2)
 
 # input: Log-likelihood and penalty values
 evSyn_LL(object, \ldots, PT = list(), type_ev = c("added", "equal", "average"),
          hypo_names = c(), type = c("goric", "goricc", "gorica", "goricac"),
          order_studies = c("input_order", "ascending", "descending"),
-         study_names = c())
+         study_names = c(), penalty_factor = 2)
 
 # input: GORIC(A), ORIC, AIC values
 evSyn_ICvalues(object, \ldots, type_ev = c("added", "average"), hypo_names = c(), 
@@ -183,10 +183,18 @@ xlab_unordered = NULL, angle_x = 30, \dots)
   If \code{NULL} (default), studies are automatically numbered 
   (1, 2, ..., K) following the order determined by \code{order_studies}.}
 
-  \item{study_sample_nobs}{a numeric vector specifying the sample size (\code{n}) 
-  for each study; only needed if \code{type = "goricac"}. 
-  In case the input is a escalc object (or a dataframe), it is inherited from the 
+  \item{study_sample_nobs}{a numeric vector specifying the sample size (\code{n})
+  for each study; only needed if \code{type = "goricac"}.
+  In case the input is a escalc object (or a dataframe), it is inherited from the
   'study_sample_nobs' column, which by default is labelled "ni".}
+
+  \item{penalty_factor}{The penalty factor adjusts the penalty in the GORIC(A) formula
+  (GORIC(A) = -2 x log-likelihood + penalty_factor x penalty). By default,
+  \code{penalty_factor = 2}, the standard for AIC-type criteria. The same penalty
+  factor is used when aggregating the evidence over the studies (and in
+  \code{leave1studyout}). When the input is a list of goric objects, the penalty
+  factor stored in those objects is used (and they must all use the same one).
+  See \code{\link{goric}} for more information.}
   
 %  \item{study_weights}{Not available yet! 
 %  a numeric vector specifying the weight for each study.
@@ -309,8 +317,9 @@ one of the S studies. For each reduced set the aggregated IC values per hypothes
 are computed using the same \code{type_ev} as in the original \code{evSyn} call:
 \itemize{
   \item \code{"added"}: column sums of the IC matrix with study \emph{s} removed.
-  \item \code{"equal"}: the column means of the PT matrix minus column sums of the LL matrix with study \emph{s}
-    removed.
+  \item \code{"equal"}: -2 times the column sums of the LL matrix plus
+    \code{penalty_factor} times the column means of the PT matrix, with study
+    \emph{s} removed (using the penalty factor from the original \code{evSyn} call).
   \item \code{"average"}: column means of the IC matrix with study \emph{s} removed.
 }
 The hypothesis with the lowest aggregated IC value is identified as the preferred 

--- a/tests/testthat/test-evSyn-penalty-factor.R
+++ b/tests/testthat/test-evSyn-penalty-factor.R
@@ -1,0 +1,122 @@
+# =============================================================================
+# Tests: penalty_factor in evSyn() en leave1studyout()
+# =============================================================================
+
+# --- Gedeelde testdata: LL en PT voor 4 studies ---
+set.seed(1)
+S <- 4
+LL_list <- lapply(1:S, function(s) {
+  c(H1 = rnorm(1, -50, 2), H2 = rnorm(1, -52, 2), Hu = rnorm(1, -49, 2))
+})
+PT_list <- lapply(1:S, function(s) c(H1 = 1.5, H2 = 2, Hu = 3))
+
+LL_m <- do.call(rbind, LL_list)
+PT_m <- do.call(rbind, PT_list)
+
+
+test_that("evSyn_LL: default penalty_factor = 2 en wordt opgeslagen", {
+  es <- evSyn(LL_list, PT = PT_list, type_ev = "equal")
+  expect_identical(es$penalty_factor, 2)
+  expect_equal(unname(es$GORICA_m), unname(-2 * LL_m + 2 * PT_m))
+})
+
+test_that("evSyn_LL: penalty_factor werkt door in GORICA_m en cumulatieve waarden", {
+  pf <- 3
+  es <- evSyn(LL_list, PT = PT_list, type_ev = "equal", penalty_factor = pf)
+  expect_identical(es$penalty_factor, pf)
+  expect_equal(unname(es$GORICA_m), unname(-2 * LL_m + pf * PT_m))
+  # finale cumulatieve equal-evidence GORICA
+  expect_equal(unname(es$Cumulative_GORICA[S, ]),
+               unname(-2 * colSums(LL_m) + pf * colMeans(PT_m)))
+})
+
+test_that("evSyn_LL: ongeldige penalty_factor geeft fout", {
+  expect_error(evSyn(LL_list, PT = PT_list, penalty_factor = -1),
+               "penalty_factor")
+  expect_error(evSyn(LL_list, PT = PT_list, penalty_factor = c(1, 2)),
+               "penalty_factor")
+})
+
+test_that("leave1studyout: 'equal' gebruikt de penalty_factor uit het evSyn object", {
+  pf <- 3
+  es <- evSyn(LL_list, PT = PT_list, type_ev = "equal", penalty_factor = pf)
+  l1o <- leave1studyout(es)
+  for (s in 1:S) {
+    keep <- seq_len(S) != s
+    expected <- -2 * colSums(LL_m[keep, , drop = FALSE]) +
+      pf * colMeans(PT_m[keep, , drop = FALSE])
+    expect_equal(unname(l1o$OverallGorica[s, ]), unname(expected))
+  }
+})
+
+test_that("leave1studyout: valt terug op penalty_factor = 2 voor oudere objecten", {
+  es <- evSyn(LL_list, PT = PT_list, type_ev = "equal")
+  es$penalty_factor <- NULL
+  l1o <- leave1studyout(es)
+  for (s in 1:S) {
+    keep <- seq_len(S) != s
+    expected <- -2 * colSums(LL_m[keep, , drop = FALSE]) +
+      2 * colMeans(PT_m[keep, , drop = FALSE])
+    expect_equal(unname(l1o$OverallGorica[s, ]), unname(expected))
+  }
+})
+
+test_that("leave1studyout: 'added' en 'average' consistent met IC's (incl. penalty_factor)", {
+  pf <- 3
+  for (tev in c("added", "average")) {
+    es <- evSyn(LL_list, PT = PT_list, type_ev = tev, penalty_factor = pf)
+    l1o <- leave1studyout(es)
+    agg <- if (tev == "added") colSums else colMeans
+    for (s in 1:S) {
+      keep <- seq_len(S) != s
+      expected <- agg(es$GORICA_m[keep, , drop = FALSE])
+      expect_equal(unname(l1o$OverallGorica[s, ]), unname(expected))
+    }
+  }
+})
+
+test_that("evSyn_est: penalty_factor werkt door in studie-specifieke en overall IC's", {
+  est1 <- c(x1 = 5.0, x2 = 3.0)
+  est2 <- c(x1 = 4.5, x2 = 2.5)
+  est3 <- c(x1 = 6.0, x2 = 2.0)
+  VCOV1 <- diag(c(0.10, 0.10))
+  VCOV2 <- diag(c(0.15, 0.15))
+  VCOV3 <- diag(c(0.12, 0.12))
+  H1 <- list(H1 = "x1 > x2")
+
+  pf <- 3
+  es <- evSyn(object = list(est1, est2, est3), VCOV = list(VCOV1, VCOV2, VCOV3),
+              hypotheses = H1, type_ev = "equal", penalty_factor = pf)
+  expect_identical(es$penalty_factor, pf)
+  # per studie: IC = -2*LL + pf*PT
+  expect_equal(unname(es$GORICA_m), unname(-2 * es$LL_m + pf * es$PT_m))
+  # leave1studyout gebruikt dezelfde penalty_factor
+  l1o <- leave1studyout(es)
+  for (s in 1:3) {
+    keep <- seq_len(3) != s
+    expected <- -2 * colSums(es$LL_m[keep, , drop = FALSE]) +
+      pf * colMeans(es$PT_m[keep, , drop = FALSE])
+    expect_equal(unname(l1o$OverallGorica[s, ]), unname(expected))
+  }
+})
+
+test_that("evSyn_gorica: penalty_factor wordt uit de goric objecten overgenomen", {
+  est1 <- c(x1 = 5.0, x2 = 3.0)
+  est2 <- c(x1 = 4.5, x2 = 2.5)
+  VCOV1 <- diag(c(0.10, 0.10))
+  VCOV2 <- diag(c(0.15, 0.15))
+  H1 <- list(H1 = "x1 > x2")
+
+  pf <- 3
+  g1 <- goric(est1, VCOV = VCOV1, type = "gorica", hypotheses = H1, penalty_factor = pf)
+  g2 <- goric(est2, VCOV = VCOV2, type = "gorica", hypotheses = H1, penalty_factor = pf)
+
+  es <- evSyn(object = list(g1, g2), type_ev = "equal")
+  expect_identical(es$penalty_factor, pf)
+  expect_equal(unname(es$GORICA_m[1, ]), unname(g1$result$gorica))
+  expect_equal(unname(es$GORICA_m[2, ]), unname(g2$result$gorica))
+
+  # verschillende penalty factors over studies is niet toegestaan
+  g2b <- goric(est2, VCOV = VCOV2, type = "gorica", hypotheses = H1, penalty_factor = 2)
+  expect_error(evSyn(object = list(g1, g2b)), "same penalty_factor")
+})


### PR DESCRIPTION
The penalty factor was only applied in goric(); when aggregating evidence over studies the factor 2 was hardcoded. Now evSyn_est() and evSyn_LL() take a penalty_factor argument (default 2), use it when computing the study-specific ICs and the cumulative/overall GORIC(A) values, and store it in the evSyn object. evSyn_gorica() takes the penalty factor from the goric objects (and checks that all studies use the same one). leave1studyout() uses the stored penalty factor in the equal-evidence branch: -2 * colSums(LL_m[keep,]) + penalty_factor * colMeans(PT_m[keep,]). Older evSyn objects without a stored penalty_factor fall back to 2.


Claude-Session: https://claude.ai/code/session_014nzt61v1uwVfruNGoSi91V