### PR TITLE
Report Wolak joint tail probability in iht type = 'summary'

### DIFF
--- a/R/conTest_print.R
+++ b/R/conTest_print.R
@@ -110,8 +110,22 @@ print.conTest <- function(x, digits = max(3, getOption("digits") - 2), ...) {
           }, "\n\n", sep = "")
     }
     ###
+    if (!is.null(x$joint)) {
+      cat("Joint Type A and Type B test (Wolak, 1989, Theorem 1):\n",
+          "        joint tail probability under H0: Rb = r (least favorable null)\n")
+      cat("       Pr[Type B >= ", sprintf("%.4f", x$joint$Ts.B),
+          ", Type A >= ", sprintf("%.4f", x$joint$Ts.A), "]:   p-value: ",
+          if (!is.na(x$joint$pvalue) && x$joint$pvalue < 1e-04) {
+            "<0.0001"
+          } else if (!is.na(x$joint$pvalue)) {
+            format(x$joint$pvalue, digits = 4)
+          } else {
+            as.numeric(NA)
+          }, "\n\n", sep = "")
+    }
+    ###
     if (!is.null(x$C)) {
-      cat("Type C test: H0: at least one restriction is false or active (==)", 
+      cat("Type C test: H0: at least one restriction is false or active (==)",
           "\n", "        vs. HA: all restrictions are strictly true (>)\n")
       cat("       Test statistic: ", sprintf("%.4f", x$C$Ts), ",   p-value: ", 
           if (!is.na(x$C$pvalue) && x$C$pvalue < 1e-04) { 

--- a/R/conTest_summary.R
+++ b/R/conTest_summary.R
@@ -29,8 +29,21 @@ conTest_summary.restriktor <- function(object, test = "F", ...) {
     OUT$C <- do.call("conTest", CALL)
     #OUT <- c(OUT, OUT4)
   }
-  
+
+  # joint tail probability of the type B and type A statistics under the
+  # shared (least favorable) null Rb = r (Wolak, 1989, Theorem 1). Only
+  # available when the marginal p-values are based on the chi-bar-square
+  # weights (no bootstrap) and under the full null (neq.alt = 0).
+  wt.bar <- object$wt.bar
+  if ((is.null(ldots$boot) || ldots$boot == "no") &&
+      (is.null(ldots$neq.alt) || ldots$neq.alt == 0L) &&
+      inherits(object, c("conLM", "conGLM", "conRLM")) &&
+      !is.null(wt.bar) && !is.null(attr(wt.bar, "method")) &&
+      attr(wt.bar, "method") != "none") {
+    OUT$joint <- con_pvalue_joint(object, Ts.A = OUT$A$Ts, Ts.B = OUT$B$Ts)
+  }
+
   class(OUT) <- c("conTest")
-  
+
   OUT
 }

--- a/R/con_iht_joint.R
+++ b/R/con_iht_joint.R
@@ -101,28 +101,9 @@ iht_joint <- function(object, constraints = NULL, test = "F",
   df.residual <- outA$df.residual
   q <- nrow(Amat)
 
-  # align wt.bar with the type A convention wt.bar[k+1] <-> chi2_k, k = 0:L.
-  # mix_weights = "pmvnorm" stores exactly L + 1 weights; mix_weights = "boot"
-  # stores level probabilities for dimensions 0:p (p = number of parameters),
-  # of which the window p-q ... p-meq corresponds to k = 0:L.
-  L <- q - meq
-  p <- length(object$b.unrestr)
-  if (length(wt.bar) == L + 1L) {
-    wt.bar.joint <- as.numeric(wt.bar)
-  } else if (length(wt.bar) == p + 1L) {
-    wt.bar.joint <- as.numeric(wt.bar[(p - q + 1L):(p - meq + 1L)])
-  } else {
-    stop("restriktor ERROR: length of wt.bar (", length(wt.bar),
-         ") does not match the number of (inequality) constraints.")
-  }
-  if (abs(sum(wt.bar.joint) - 1) > 1e-04) {
-    warning("restriktor WARNING: chi-bar-square weights do not sum to 1 (sum = ",
-            round(sum(wt.bar.joint), 6), "); the joint p-value may be inaccurate.")
-  }
-
-  # joint tail probability Pr[IU >= Ts.B, EI >= Ts.A] under Rb = r
-  pvalue.joint <- pfbar_joint(cIU = outB$Ts, cEI = outA$Ts, df_total = q,
-                              df2 = df.residual, wt.bar = wt.bar.joint)
+  joint <- con_pvalue_joint(object, Ts.A = outA$Ts, Ts.B = outB$Ts)
+  wt.bar.joint <- joint$wt.bar
+  pvalue.joint <- joint$pvalue
 
   # combined decision rule at level alpha, based on the marginal tests:
   #  (a) H0: Rb = r is retained          (type A not rejected)
@@ -162,6 +143,43 @@ iht_joint <- function(object, constraints = NULL, test = "F",
   class(OUT) <- "conTestJoint"
 
   OUT
+}
+
+
+# internal workhorse shared by iht_joint() and conTest_summary(): the joint
+# tail probability Pr[IU >= Ts.B, EI >= Ts.A] under the least favorable null
+# Rb = r (Wolak, 1989, Theorem 1; F-bar form of Wolak, 1987, Theorem 4.4),
+# computed from the cached chi-bar-square weights on the restriktor object.
+con_pvalue_joint <- function(object, Ts.A, Ts.B) {
+  Amat <- object$constraints
+  meq  <- object$neq
+  q <- nrow(Amat)
+
+  # align wt.bar with the type A convention wt.bar[k+1] <-> chi2_k, k = 0:L.
+  # mix_weights = "pmvnorm" stores exactly L + 1 weights; mix_weights = "boot"
+  # stores level probabilities for dimensions 0:p (p = number of parameters),
+  # of which the window p-q ... p-meq corresponds to k = 0:L.
+  wt.bar <- object$wt.bar
+  L <- q - meq
+  p <- length(object$b.unrestr)
+  if (length(wt.bar) == L + 1L) {
+    wt.bar.joint <- as.numeric(wt.bar)
+  } else if (length(wt.bar) == p + 1L) {
+    wt.bar.joint <- as.numeric(wt.bar[(p - q + 1L):(p - meq + 1L)])
+  } else {
+    stop("restriktor ERROR: length of wt.bar (", length(wt.bar),
+         ") does not match the number of (inequality) constraints.")
+  }
+  if (abs(sum(wt.bar.joint) - 1) > 1e-04) {
+    warning("restriktor WARNING: chi-bar-square weights do not sum to 1 (sum = ",
+            round(sum(wt.bar.joint), 6), "); the joint p-value may be inaccurate.")
+  }
+
+  pvalue <- pfbar_joint(cIU = Ts.B, cEI = Ts.A, df_total = q,
+                        df2 = object$df.residual, wt.bar = wt.bar.joint)
+
+  list(pvalue = pvalue, wt.bar = wt.bar.joint, Ts.A = Ts.A, Ts.B = Ts.B,
+       df.residual = object$df.residual)
 }
 
 

--- a/man/conTest_summary.Rd
+++ b/man/conTest_summary.Rd
@@ -7,9 +7,16 @@
 
 }
 \description{conTest_summary computes all available hypothesis tests and returns
-and object of class \code{conTest} for which a print function is available. The 
-\code{conTest_summary} can be used directly and is called by the \code{conTest} 
-function if \code{type = "summary"}. 
+and object of class \code{conTest} for which a print function is available. The
+\code{conTest_summary} can be used directly and is called by the \code{conTest}
+function if \code{type = "summary"}.
+
+In addition to the marginal tests, the summary reports the joint tail
+probability of the type B and type A statistics under the shared (least
+favorable) null hypothesis \eqn{R\theta = rhs} (Wolak, 1989, Theorem 1; see
+\code{\link{iht_joint}}). The joint element is only included when the
+marginal p-values are based on the chi-bar-square weights (i.e., no
+bootstrap, \code{neq.alt = 0}, and \code{mix_weights} not \code{"none"}).
 }
 
 \usage{

--- a/man/iht_joint.Rd
+++ b/man/iht_joint.Rd
@@ -151,6 +151,10 @@ least one constraint must be an inequality.
 
   \code{pchibar_joint} and \code{pfbar_joint} return the joint upper
   tail probability (a single number in [0, 1]).
+
+  The joint tail probability is also reported by
+  \code{iht(..., type = "summary")} (see \code{\link{conTest_summary}}),
+  next to the marginal type A and type B results.
 }
 
 \references{

--- a/tests/testthat/test-iht_joint.R
+++ b/tests/testthat/test-iht_joint.R
@@ -248,6 +248,29 @@ test_that("print.conTestJoint geeft leesbare output", {
 
 
 # =============================================================================
+# Integratie in conTest_summary / iht(type = "summary")
+# =============================================================================
+
+test_that("iht(type = 'summary') bevat de joint p-waarde (Wolak)", {
+  s <- iht(con_lm)  # type = "summary" is de default
+  expect_false(is.null(s$joint))
+  expect_equal(s$joint$pvalue, out_joint$pvalue.joint, tolerance = 1e-10)
+  expect_equal(s$joint$Ts.A, out_joint$Ts.A, tolerance = 1e-10)
+  expect_equal(s$joint$Ts.B, out_joint$Ts.B, tolerance = 1e-10)
+  # print toont de joint-regel
+  txt <- capture.output(print(s))
+  expect_true(any(grepl("Joint Type A and Type B test \\(Wolak", txt)))
+})
+
+test_that("summary zonder chi-bar-gewichten of met bootstrap: geen joint", {
+  con_nw <- restriktor(fit_lm, constraints = "group1 < group2 < group3",
+                       mix_weights = "none")
+  s_nw <- iht(con_nw, boot = "parametric", R = 9)
+  expect_true(is.null(s_nw$joint))
+})
+
+
+# =============================================================================
 # Beslisregel en foutafhandeling
 # =============================================================================
 


### PR DESCRIPTION
conTest_summary() now computes the joint tail probability of the type B and type A statistics under the shared null Rb = r and print.conTest shows it next to the marginal tests. The computation is shared with iht_joint() via the internal helper con_pvalue_joint(). The joint element is omitted when the marginal p-values are bootstrap-based, neq.alt > 0, or no chi-bar-square weights are available.


Claude-Session: https://claude.ai/code/session_01AW1umWXTH5BrzvzMJkFwyB