### PR TITLE
Fix defects found in review of the FIML and joint-test features

### DIFF
--- a/R/conTest_conGLM.R
+++ b/R/conTest_conGLM.R
@@ -158,7 +158,7 @@ conTestF.conGLM <- function(object, type = "A", neq.alt = 0, boot = "no", R = 99
     attr(pvalue, "mix_weights_bootstrap_limit") <- attr(wt.bar, "mix_weights_bootstrap_limit")
     
     attr(pvalue, "wt_bar_chunk") <- attr(wt.bar, "wt_bar_chunk")
-    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size_org")
+    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size")
     attr(pvalue, "total_chunks") <- attr(wt.bar, "total_chunks")
     attr(pvalue, "chunk_iter"  ) <- attr(wt.bar, "chunk_iter")
     
@@ -390,7 +390,7 @@ conTestLRT.conGLM <- function(object, type = "A", neq.alt = 0, boot = "no", R = 
     attr(pvalue, "mix_weights_bootstrap_limit") <- attr(wt.bar, "mix_weights_bootstrap_limit")
     
     attr(pvalue, "wt_bar_chunk") <- attr(wt.bar, "wt_bar_chunk")
-    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size_org")
+    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size")
     attr(pvalue, "total_chunks") <- attr(wt.bar, "total_chunks")
     attr(pvalue, "chunk_iter"  ) <- attr(wt.bar, "chunk_iter")
     
@@ -717,7 +717,7 @@ conTestScore.conGLM <- function(object, type = "A", neq.alt = 0, boot = "no", R 
     attr(pvalue, "mix_weights_bootstrap_limit") <- attr(wt.bar, "mix_weights_bootstrap_limit")
     
     attr(pvalue, "wt_bar_chunk") <- attr(wt.bar, "wt_bar_chunk")
-    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size_org")
+    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size")
     attr(pvalue, "total_chunks") <- attr(wt.bar, "total_chunks")
     attr(pvalue, "chunk_iter"  ) <- attr(wt.bar, "chunk_iter")
 

--- a/R/conTest_conLM.R
+++ b/R/conTest_conLM.R
@@ -186,7 +186,7 @@ conTestF.conLM <- function(object, type = "A", neq.alt = 0, boot = "no", R = 999
     attr(pvalue, "mix_weights_bootstrap_limit") <- attr(wt.bar, "mix_weights_bootstrap_limit")
     
     attr(pvalue, "wt_bar_chunk") <- attr(wt.bar, "wt_bar_chunk")
-    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size_org")
+    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size")
     attr(pvalue, "total_chunks") <- attr(wt.bar, "total_chunks")
     attr(pvalue, "chunk_iter"  ) <- attr(wt.bar, "chunk_iter")
     
@@ -472,7 +472,7 @@ conTestLRT.conLM <- function(object, type = "A", neq.alt = 0, boot = "no", R = 9
     attr(pvalue, "mix_weights_bootstrap_limit") <- attr(wt.bar, "mix_weights_bootstrap_limit")
     
     attr(pvalue, "wt_bar_chunk") <- attr(wt.bar, "wt_bar_chunk")
-    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size_org")
+    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size")
     attr(pvalue, "total_chunks") <- attr(wt.bar, "total_chunks")
     attr(pvalue, "chunk_iter"  ) <- attr(wt.bar, "chunk_iter")
 
@@ -819,7 +819,7 @@ conTestScore.conLM <- function(object, type = "A", neq.alt = 0, boot = "no", R =
     attr(pvalue, "mix_weights_bootstrap_limit") <- attr(wt.bar, "mix_weights_bootstrap_limit")
     
     attr(pvalue, "wt_bar_chunk") <- attr(wt.bar, "wt_bar_chunk")
-    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size_org")
+    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size")
     attr(pvalue, "total_chunks") <- attr(wt.bar, "total_chunks")
     attr(pvalue, "chunk_iter"  ) <- attr(wt.bar, "chunk_iter")
     

--- a/R/conTest_conMLM.R
+++ b/R/conTest_conMLM.R
@@ -197,7 +197,7 @@ conTestLRT.conMLM <- function(object, type = "A", neq.alt = 0, boot = "no", R = 
     attr(pvalue, "mix_weights_bootstrap_limit") <- attr(wt.bar, "mix_weights_bootstrap_limit")
     
     attr(pvalue, "wt_bar_chunk") <- attr(wt.bar, "wt_bar_chunk")
-    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size_org")
+    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size")
     attr(pvalue, "total_chunks") <- attr(wt.bar, "total_chunks")
     attr(pvalue, "chunk_iter"  ) <- attr(wt.bar, "chunk_iter")
     

--- a/R/conTest_conRLM.R
+++ b/R/conTest_conRLM.R
@@ -183,7 +183,7 @@ conTestF.conRLM <- function(object, type = "A", neq.alt = 0, boot = "no", R = 99
     attr(pvalue, "mix_weights_bootstrap_limit") <- attr(wt.bar, "mix_weights_bootstrap_limit")
     
     attr(pvalue, "wt_bar_chunk") <- attr(wt.bar, "wt_bar_chunk")
-    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size_org")
+    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size")
     attr(pvalue, "total_chunks") <- attr(wt.bar, "total_chunks")
     attr(pvalue, "chunk_iter"  ) <- attr(wt.bar, "chunk_iter")
     
@@ -449,7 +449,7 @@ conTestWald.conRLM <- function(object, type = "A", neq.alt = 0, boot = "no", R =
     attr(pvalue, "mix_weights_bootstrap_limit") <- attr(wt.bar, "mix_weights_bootstrap_limit")
     
     attr(pvalue, "wt_bar_chunk") <- attr(wt.bar, "wt_bar_chunk")
-    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size_org")
+    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size")
     attr(pvalue, "total_chunks") <- attr(wt.bar, "total_chunks")
     attr(pvalue, "chunk_iter"  ) <- attr(wt.bar, "chunk_iter")
     
@@ -759,7 +759,7 @@ conTestScore.conRLM <- function(object, type = "A", neq.alt = 0, boot = "no", R 
     attr(pvalue, "mix_weights_bootstrap_limit") <- attr(wt.bar, "mix_weights_bootstrap_limit")
     
     attr(pvalue, "wt_bar_chunk") <- attr(wt.bar, "wt_bar_chunk")
-    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size_org")
+    attr(pvalue, "chunk_size"  ) <- attr(wt.bar, "chunk_size")
     attr(pvalue, "total_chunks") <- attr(wt.bar, "total_chunks")
     attr(pvalue, "chunk_iter"  ) <- attr(wt.bar, "chunk_iter")
     

--- a/R/con_fiml.R
+++ b/R/con_fiml.R
@@ -59,9 +59,30 @@ fiml_lm_data <- function(object, auxiliary = c()) {
     }
   }
 
+  # apply a subset argument the same way lm() did
+  subsetcall <- getCall(object)$subset
+  if (!is.null(subsetcall)) {
+    subs <- try(eval(subsetcall, envir = data, enclos = env), silent = TRUE)
+    if (inherits(subs, "try-error")) {
+      stop(paste("restriktor ERROR: the 'subset' argument of the fitted model",
+                 "could not be evaluated on the recovered data."), call. = FALSE)
+    }
+    if (is.logical(subs)) {
+      subs <- which(subs)
+    }
+    data <- data[subs, , drop = FALSE]
+  }
+
+  # convert character variables to factors, as lm() does internally
+  for (j in seq_along(data)) {
+    if (is.character(data[[j]])) {
+      data[[j]] <- factor(data[[j]])
+    }
+  }
+
   # model frame with missing values preserved
   mf <- model.frame(delete.response(terms(object)), data = data, na.action = na.pass)
-  y  <- eval(form[[2L]], envir = data)
+  y  <- eval(form[[2L]], envir = data, enclos = env)
   if (!is.numeric(y) || !is.null(dim(y))) {
     stop("restriktor ERROR: missing = \"fiml\" requires a single numeric response variable.",
          call. = FALSE)
@@ -97,7 +118,7 @@ fiml_lm_data <- function(object, auxiliary = c()) {
                  paste(sQuote(auxiliary[!is_num]), collapse = ", ")), call. = FALSE)
     }
     A <- as.matrix(A)
-    dup <- intersect(colnames(A), c("y__", colnames(X)))
+    dup <- intersect(colnames(A), c(deparse(form[[2L]]), colnames(X)))
     if (length(dup) > 0L) {
       stop("restriktor ERROR: auxiliary variable(s) also appear in the model: ",
            paste(sQuote(dup), collapse = ", "), call. = FALSE)

--- a/R/con_pvalue.R
+++ b/R/con_pvalue.R
@@ -1,13 +1,25 @@
 # mixture of F distributions.
 con_pvalue_Fbar <- function(wt.bar, Ts.org, df.residual, type = "A",
                             Amat, bvec, meq = 0L, meq.alt = 0L) {
-  
-  # wt.method <- attr(wt.bar, "method")
-  # if (wt.method == "boot") {
-  #   idx.start <- (ncol(Amat) - nrow(Amat)) + 1
-  #   idx.end   <- (ncol(Amat) - meq) + 1
-  # }
-  
+
+  # mix_weights = "pmvnorm" stores nrow(Amat) - meq + 1 weights in the type A
+  # convention (wt.bar[k+1] <-> chi2_k). mix_weights = "boot" stores level
+  # probabilities for the dimensions 0:p (p = number of parameters), of which
+  # the window p - q ... p - meq corresponds to k = 0 ... q - meq. Without
+  # this alignment the mixture below would recycle the weights and produce
+  # wrong p-values.
+  wt.method <- attr(wt.bar, "method")
+  if (!is.null(wt.method) && wt.method == "boot" &&
+      length(wt.bar) == ncol(Amat) + 1L &&
+      length(wt.bar) != nrow(Amat) - meq + 1L) {
+    idx.start <- (ncol(Amat) - nrow(Amat)) + 1L
+    idx.end   <- (ncol(Amat) - meq) + 1L
+    wt.bar.attr <- attributes(wt.bar)
+    wt.bar <- wt.bar[idx.start:idx.end]
+    wt.bar.attr$names <- NULL
+    attributes(wt.bar) <- c(attributes(wt.bar), wt.bar.attr)
+  }
+
   if (type == "global") {
     # compute df
     bvecG <- attr(bvec, "bvec.global")

--- a/tests/testthat/test-conTest.R
+++ b/tests/testthat/test-conTest.R
@@ -158,3 +158,27 @@ test_that("conTest conRLM fout bij LRT (niet beschikbaar)", {
   expect_error(conTest(con_rlm, type = "A", test = "LRT"), "unknown")
 })
 
+
+test_that("iht p-waarden met mix_weights = 'boot' komen overeen met 'pmvnorm'", {
+  # regression test: the boot engine stores level probabilities for the
+  # dimensions 0:p (p + 1 weights), while the F-bar mixture needs the
+  # window that corresponds to k = 0 ... q - meq. Before the fix in
+  # con_pvalue_Fbar the weights were recycled, yielding wrong p-values.
+  set.seed(3)
+  n <- 150
+  x1 <- rnorm(n); x2 <- rnorm(n); x3 <- rnorm(n)
+  y <- 1 + 0.3*x1 + 0.2*x2 + rnorm(n)
+  fit <- lm(y ~ x1 + x2 + x3, data = data.frame(y, x1, x2, x3))
+
+  for (constr in c("x1 > 0; x2 > 0; x3 > 0", "x1 == 0.3; x2 > 0; x3 > 0")) {
+    r_pmv  <- restriktor(fit, constraints = constr)
+    r_boot <- restriktor(fit, constraints = constr, mix_weights = "boot",
+                         seed = 7)
+    for (tp in c("A", "B")) {
+      p_pmv  <- iht(r_pmv,  type = tp)$pvalue
+      p_boot <- expect_no_warning(iht(r_boot, type = tp)$pvalue)
+      # boot weights carry Monte Carlo error; agreement within 0.01 suffices
+      expect_equal(as.numeric(p_boot), as.numeric(p_pmv), tolerance = 1e-2)
+    }
+  }
+})

--- a/tests/testthat/test-fiml.R
+++ b/tests/testthat/test-fiml.R
@@ -191,6 +191,38 @@ test_that("fiml works with factors and interactions", {
 })
 
 
+test_that("fiml respects the subset argument of the lm fit", {
+  df <- gen_fiml_data()
+  fit <- lm(y ~ x1 + x2 + x3, data = df, subset = x1 > 0)
+
+  r <- restriktor(fit, constraints = "x1 > 0", missing = "fiml")
+  n_subset <- sum(df$x1 > 0)
+  expect_equal(r$fiml$N, sum(rowSums(!is.na(df[df$x1 > 0, 1:4])) > 0))
+  expect_lte(r$fiml$N, n_subset)
+})
+
+
+test_that("fiml handles character predictors like factors", {
+  set.seed(11)
+  n <- 200
+  x1 <- rnorm(n)
+  g_chr <- sample(c("a", "b", "c"), n, replace = TRUE)
+  y <- 1 + 0.8 * x1 + 0.5 * (g_chr == "b") + rnorm(n)
+  df <- data.frame(y, x1, g = g_chr, stringsAsFactors = FALSE)
+  df$y[runif(n) < 0.2] <- NA
+  df$g[runif(n) < 0.2] <- NA
+
+  fit_chr <- lm(y ~ x1 + g, data = df)
+  df_fac <- df
+  df_fac$g <- factor(df_fac$g)
+  fit_fac <- lm(y ~ x1 + g, data = df_fac)
+
+  r_chr <- restriktor(fit_chr, constraints = "gb > 0", missing = "fiml")
+  r_fac <- restriktor(fit_fac, constraints = "gb > 0", missing = "fiml")
+  expect_equal(coef(r_chr), coef(r_fac), tolerance = 1e-8)
+})
+
+
 test_that("fiml error handling", {
   df <- gen_fiml_data()
   fit <- lm(y ~ x1 + x2 + x3, data = df)
@@ -215,4 +247,9 @@ test_that("fiml error handling", {
   fitw <- lm(y ~ x1 + x2 + x3, data = df, weights = rep(1, nrow(df)))
   expect_error(restriktor(fitw, constraints = "x1 > 0", missing = "fiml"),
                "weighted")
+  # auxiliary equal to the response or a model variable
+  expect_error(restriktor(fit, constraints = "x1 > 0", missing = "fiml",
+                          auxiliary = "y"), "auxiliary")
+  expect_error(restriktor(fit, constraints = "x1 > 0", missing = "fiml",
+                          auxiliary = "x1"), "auxiliary")
 })


### PR DESCRIPTION
FIML (missing = "fiml"):
- honor the 'subset' argument of the fitted lm object; it was silently ignored, so the FIML fit used all rows of the recovered data instead of the subset the model was fitted on
- convert character variables to factors before building the model frame (as lm() does internally); character predictors with missing values crashed with "contrasts can be applied only to factors with 2 or more levels", and the dummy-fill in fiml_model_matrix could produce misaligned columns
- fix the duplicate-name check for auxiliary variables: it compared against the placeholder "y__" instead of the actual response name, so auxiliary = <response> failed with a cryptic Cholesky error instead of an informative message
- evaluate the response with the formula environment as enclosure

conTest/iht with mix_weights = "boot" (pre-existing, also in CRAN 0.6-50, surfaced by the marginal-consistency check against the new con_pvalue_joint):
- con_pvalue_Fbar mixed the q - meq + 1 F-tail terms with the full p + 1 vector of bootstrapped level probabilities, recycling the weights (with only a length warning) and producing badly wrong type A/B/global p-values (e.g. 0.127 instead of 2e-06). Align the boot weights to the k = 0 ... q - meq window first, exactly as con_pvalue_joint and penalty_goric already did. pmvnorm results are unchanged; boot results now agree with pmvnorm within Monte Carlo error (regression test added).
- read the correct "chunk_size" attribute off wt.bar in all conTest_* files ("chunk_size_org" never existed, so the reported attribute was always NULL)

Verified clean across edge cases: transformed responses/predictors, na.exclude, models without a data argument, ordered factors, logicals, interactions with missing values, tibble input, factor levels that only occur in incomplete rows, matrix constraints via goric, equality-only constraints, Heq, and comparison = "none"; joint-test marginals match conTest for lm/glm/rlm, F/LRT, meq > 0, and both weight engines.


Claude-Session: https://claude.ai/code/session_01Vj3oz3iHUfnqWVKHoexhJD