### PR TITLE
Fix robust SE bugs and align con_sandwich.R with sandwich 3.1-0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,10 +24,11 @@ NeedsCompilation: no
 Packaged: 2026-07-15 11:11:11 UTC; leonardv
 Author: Leonard Vanbrabant [aut, cre], Rebecca Kuiper [aut], Yves Rosseel [ctb], Aleksandra Dacko [ctb]
 Maintainer: Leonard Vanbrabant <info@restriktor.org>
-Suggests: 
+Suggests:
     knitr,
     rmarkdown,
     bain,
+    sandwich,
     testthat (>= 3.0.0),
     metadat
 VignetteBuilder: knitr

--- a/R/conLM.R
+++ b/R/conLM.R
@@ -354,6 +354,12 @@ conLM.lm <- function(object, constraints = NULL, se = "standard",
     X <- chol(OUT$information)
   } else {
     OUT$missing <- "none"
+    # for weighted least squares the information is based on the weighted
+    # model matrix; con_augmented_information() below then also derives the
+    # Lagrange multipliers from crossprod(X) = X'WX
+    if (!is.null(weights)) {
+      X <- sqrt(weights) * X
+    }
     OUT$information <- 1/s2 * crossprod(X)
   }
   

--- a/R/con_sandwich.R
+++ b/R/con_sandwich.R
@@ -1,7 +1,13 @@
-# adjusted functions from the sandwich package.
-# adapted by LV.
+# adjusted functions from the sandwich package (based on sandwich version 3.1-0).
+# adapted for restricted estimation by LV.
+#
+# the bread functions replace the classical unscaled covariance matrix by the
+# inverted augmented information matrix (Schoenberg, 1997), so that the
+# (in)equality restrictions are taken into account. without restrictions the
+# results are identical to sandwich::vcovHC().
 
 sandwich <- function(x, bread. = bread, meat. = meatHC, ...) {
+  if (is.list(x) && !is.null(x$na.action)) { class(x$na.action) <- "omit" }
   if (is.function(bread.)) { bread. <- bread.(x) }
   if (is.function(meat.)) { meat. <- meat.(x, ...) }
   n <- NROW(estfun(x))
@@ -21,27 +27,29 @@ bread.conLM <- function(x, ...) {
 
 
 bread.conRLM <- function(x, ...) {
-    xmat <- model.matrix(x)
-    wts <- weights(x)
-    if (is.null(wts)) { wts <- 1 }
-    res <- residuals(x)
-    psi_deriv <- function(z) x$model.org$psi(z, deriv = 1)
-    rval <- sqrt(abs(as.vector(psi_deriv(res / x$model.org$s) / x$model.org$s))) * wts * xmat    
-    rval <- chol2inv(qr.R(qr(rval))) * nrow(xmat)
-    rval <- solve(rval) 
-    
-    is.augmented <- TRUE
-    if (all(c(x$constraints) == 0)) { is.augmented <- FALSE }
-    
-    rval <- con_augmented_information(information  = rval, 
-                                      is.augmented = is.augmented,
-                                      X            = xmat, 
-                                      b.unrestr    = x$b.unrestr, 
-                                      b.restr      = x$b.restr, 
-                                      Amat         = x$constraints, 
-                                      bvec         = x$rhs, 
-                                      meq          = x$neq)
-    return(rval$information)
+  xmat <- model.matrix(x)
+  wts <- weights(x)
+  if (is.null(wts)) { wts <- 1 }
+  res <- residuals(x)
+  # x$scale is re-estimated under the restrictions; it equals x$model.org$s
+  # when no restrictions are violated.
+  psi_deriv <- function(z) x$model.org$psi(z, deriv = 1)
+  rval <- sqrt(abs(as.vector(psi_deriv(res / x$scale) / x$scale))) * wts * xmat
+  rval <- chol2inv(qr.R(qr(rval))) * nrow(xmat)
+  rval <- solve(rval)
+
+  is.augmented <- TRUE
+  if (all(c(x$constraints) == 0)) { is.augmented <- FALSE }
+
+  rval <- con_augmented_information(information  = rval,
+                                    is.augmented = is.augmented,
+                                    X            = xmat,
+                                    b.unrestr    = x$b.unrestr,
+                                    b.restr      = x$b.restr,
+                                    Amat         = x$constraints,
+                                    bvec         = x$rhs,
+                                    meq          = x$neq)
+  return(rval$information)
 }
 
 
@@ -53,12 +61,13 @@ bread.conGLM <- function(x, ...) {
   } else {
     sum(wres^2) / sum(weights(x, "working"))
   }
-  
-  cov <- attr(x$information, "inverted") #* x$df.residual / as.vector(sum(sx$df[1:2]))
+
+  # x$information is scaled by 1/x$dispersion, hence the inverted information
+  # is unscaled here and rescaled with the ML-type dispersion, exactly as in
+  # sandwich::bread.glm().
+  cov <- attr(x$information, "inverted")
   cov.unscaled <- cov / x$dispersion
-  
-  #cov.unscaled <- 1 / dispersion.restr * I.inv
-  
+
   return(cov.unscaled * as.vector(sum(sx$df[1:2])) * dispersion.restr)
 }
 
@@ -70,8 +79,8 @@ estfun <- function(x, ...) {
 estfun.conLM <- function(x, ...) {
   xmat <- model.matrix(x)
   xmat <- naresid(x$na.action, xmat)
-  if (any(alias <- is.na(coef(x)))) { 
-    xmat <- xmat[, !alias, drop = FALSE] 
+  if (any(alias <- is.na(coef(x)))) {
+    xmat <- xmat[, !alias, drop = FALSE]
   }
   wts <- weights(x)
   if (is.null(wts)) { wts <- 1 }
@@ -85,11 +94,12 @@ estfun.conLM <- function(x, ...) {
 
 estfun.conRLM <- function(x, ...) {
   xmat <- model.matrix(x)
+  xmat <- naresid(x$na.action, xmat)
   wts <- weights(x)
   if (is.null(wts)) { wts <- 1 }
   res <- residuals(x)
   psi <- function(z) x$model.org$psi(z) * z
-  rval <- as.vector(psi(res/x$model.org$s)) * wts * xmat
+  rval <- as.vector(psi(res / x$scale)) * wts * xmat
   attr(rval, "assign") <- NULL
   attr(rval, "contrasts") <- NULL
 
@@ -99,6 +109,7 @@ estfun.conRLM <- function(x, ...) {
 
 estfun.conGLM <- function(x, ...) {
   xmat <- model.matrix(x)
+  xmat <- naresid(x$na.action, xmat)
   if (any(alias <- is.na(coef(x)))) {
     xmat <- xmat[, !alias, drop = FALSE]
   }
@@ -108,83 +119,80 @@ estfun.conGLM <- function(x, ...) {
   } else {
     sum(wres^2, na.rm = TRUE) / sum(weights(x, "working"), na.rm = TRUE)
   }
-  
+
   rval <- wres * xmat / dispersion
   attr(rval, "assign") <- NULL
   attr(rval, "contrasts") <- NULL
-#  res <- residuals(x, type = "pearson")
-#  if(is.ts(res)) rval <- ts(rval, start = start(res), frequency = frequency(res))
-#  if(is.zoo(res)) rval <- zoo(rval, index(res), attr(res, "frequency"))
+
   return(rval)
 }
 
 
-meatHC <- function(x, 
+meatHC <- function(x,
                    type = c("HC3", "const", "HC", "HC0", "HC1", "HC2", "HC4", "HC4m", "HC5"),
                    omega = NULL) {
-  
+
+  if (is.list(x) && !is.null(x$na.action)) { class(x$na.action) <- "omit" }
+
+  type <- match.arg(type)
+  if (type == "HC") { type <- "HC0" }
+
   X <- model.matrix(x$model.org)
   if (any(alias <- is.na(coef(x)))) X <- X[, !alias, drop = FALSE]
   attr(X, "assign") <- NULL
   n <- NROW(X)
-  
-  ### get hat values and residual degrees of freedom ###
+
+  # correct the residual degrees of freedom for equality constraints
+  df <- n - (NCOL(X) - qr(x$constraints[seq_len(x$neq), , drop = FALSE])$rank)
+
+  ### get hat values ###
+  # hatvalues() cannot be applied to restricted model objects, hence the
+  # diagonal of the hat matrix is computed directly via a QR factorization
+  # of the (weighted) model matrix.
   if (type %in% c("HC2", "HC3", "HC4", "HC4m", "HC5")) {
     if (inherits(x, "conRLM")) {
-      rW <- sqrt(x$w)
-    } else if (inherits(x, "conLM")) {
-        if (!is.null(x$weights)) {
-          rW <- sqrt(x$weights)
-        } else {
-          rW <- rep(1, n)
-        }
+      # weights from the IWLS process (psi(resid/scale))
+      rW <- sqrt(x$wgt)
     } else if (inherits(x, "conGLM")) {
+      # working weights
       rW <- sqrt(x$weights)
-      }
-    
-    # it may happen that a weight equals 0.
-    # to avoid computational issues, we replace the zero with 1e-08
-    idx.rW <- which(rW == 0)
-    rW[idx.rW] <- 1e-08
-    
-    if (any(rW == 0)) {
-      warning(paste("Restriktor WARNING: The following weights", idx.rW, "are exactly zero. This can lead to issues when", 
-                    "\ncalculating the hat-matrix. To compute the", sQuote(type), "standard errors, a small",
-                    "\nvalue of 1e-08 has been added. Please note that the results may be less reliable."))
+    } else if (!is.null(x$weights)) {
+      # prior weights (weighted least squares)
+      rW <- sqrt(x$weights)
+    } else {
+      rW <- rep(1, n)
     }
-    
-    ## matrix form ##
-    # diaghat <- diag(X %*% solve(t(X) %*% W %*% X) %*% t(X) %*% W)
-    
-    # QR factorization #
-    # rescaled X
-    rWX <- rW * X
-    # QR factorization
-    QR <- qr.default(rWX)
+
+    QR <- qr.default(rW * X)
     Q <- qr.qy(QR, diag(1, nrow = nrow(QR$qr), ncol = QR$rank))
-    # for weighted least squares
-    Q1 <- (1 / rW) * Q
-    Q2 <- rW * Q
-    ## diagonal
-    diaghat <- rowSums(Q1 * Q2)  
+    # diagonal of the hat matrix; observations with a zero weight simply get
+    # a zero hat value.
+    diaghat <- rowSums(Q^2)
   }
-  
-  
-  p <- NCOL(X)
-  # correct df for equality constraints
-  df <- n - (p - qr(x$constraints[0:x$neq,])$rank)
-  ## the following might work, but "intercept" is also claimed for "coxph"
-  ## res <- if(attr(terms(x), "intercept") > 0) estfun(x)[,1] else rowMeans(estfun(x)/X, na.rm = TRUE)
-  ## hence better rely on
+
+  ## extract the empirical estimating functions and residuals
   ef <- estfun(x)
-  res <- rowMeans(ef/X, na.rm = TRUE)
+  res <- rowMeans(ef / X, na.rm = TRUE)
   ## handle rows with just zeros
-  res[apply(abs(ef) < .Machine$double.eps, 1L, all)] <- 0
-  
+  all0 <- apply(abs(ef) < .Machine$double.eps, 1L, all)
+  res[all0] <- 0
+  ## in case of just zeros the residuals cannot be recovered from the
+  ## estimating functions; for the "const" estimator fall back to the model
+  ## residuals (e.g., observations fully downweighted by conRLM)
+  if (any(all0) && type == "const") {
+    if (inherits(x, "conGLM")) {
+      res <- as.vector(residuals(x, "working")) * weights(x, "working")
+      if (!(substr(x$model.org$family$family, 1L, 17L) %in% c("poisson", "binomial", "Negative Binomial"))) {
+        res <- res * sum(weights(x, "working"), na.rm = TRUE) / sum(res^2, na.rm = TRUE)
+      }
+    } else {
+      res <- as.vector(residuals(x))
+      if (!is.null(weights(x))) { res <- res * weights(x) }
+    }
+  }
+
   ## if omega not specified, set up using type
   if (is.null(omega)) {
-    type <- match.arg(type)
-    if (type == "HC") type <- "HC0"
     switch (type,
            "const" = { omega <- function(residuals, diaghat, df) rep(1, length(residuals)) * sum(residuals^2)/df },
            "HC0"   = { omega <- function(residuals, diaghat, df) residuals^2 },
@@ -213,11 +221,11 @@ meatHC <- function(x,
            }}
     )
   }
-  
+
   ## process omega
   if (is.function(omega)) { omega <- omega(res, diaghat, df) }
   rval <- sqrt(omega) * X
   rval <- crossprod(rval) / n
-  
+
   return(rval)
 }

--- a/tests/testthat/test-con_sandwich.R
+++ b/tests/testthat/test-con_sandwich.R
@@ -1,0 +1,173 @@
+# =============================================================================
+# Tests: con_sandwich.R (sandwich, bread, estfun, meatHC)
+#
+# Twee exacte referenties:
+#  1. inactieve restricties: alle HC-types moeten sandwich::vcovHC() exact
+#     reproduceren (b.restr == b.unrestr, augmentatie is een no-op).
+#  2. equality constraint x1 == x2: identiek aan het geherparametriseerde
+#     model y ~ I(x1 + x2) + ..., dus V == J %*% vcovHC(reduced) %*% t(J).
+# =============================================================================
+
+skip_if_not_installed("sandwich")
+
+set.seed(1234)
+n_sw  <- 100
+x1_sw <- rnorm(n_sw); x2_sw <- rnorm(n_sw); x3_sw <- rnorm(n_sw)
+# heteroskedastische fouten zodat de HC-correcties er echt toe doen
+e_sw  <- rnorm(n_sw, sd = 0.5 + 0.8 * abs(x1_sw))
+y_sw  <- 1 + 0.5 * x1_sw + 0.6 * x2_sw - 0.3 * x3_sw + e_sw
+df_sw <- data.frame(y = y_sw, x1 = x1_sw, x2 = x2_sw, x3 = x3_sw)
+
+# J-matrix voor herparametrisatie b(x1) == b(x2): b_vol = J %*% b_gereduceerd
+J_sw <- rbind(c(1, 0, 0),
+              c(0, 1, 0),
+              c(0, 1, 0),
+              c(0, 0, 1))
+
+hc_types_sw <- c("const", "HC0", "HC1", "HC2", "HC3", "HC4", "HC4m", "HC5")
+
+# -----------------------------------------------------------------------------
+# conLM
+# -----------------------------------------------------------------------------
+
+test_that("conLM: inactieve restricties reproduceren sandwich::vcovHC exact", {
+  fit <- lm(y ~ x1 + x2 + x3, data = df_sw)
+  for (tp in hc_types_sw) {
+    z <- restriktor(fit, constraints = "x1 > -100; x2 > -100", se = tp,
+                    mix_weights = "none")
+    expect_equal(unname(summary(z)$V), unname(sandwich::vcovHC(fit, type = tp)),
+                 tolerance = 1e-10, label = paste("conLM", tp))
+  }
+})
+
+test_that("conLM: equality constraint == geherparametriseerd model", {
+  fit     <- lm(y ~ x1 + x2 + x3, data = df_sw)
+  fit_red <- lm(y ~ I(x1 + x2) + x3, data = df_sw)
+  for (tp in c("const", "HC0", "HC1")) {
+    z <- restriktor(fit, constraints = "x1 == x2", se = tp, mix_weights = "none")
+    expect_equal(unname(summary(z)$V),
+                 unname(J_sw %*% sandwich::vcovHC(fit_red, type = tp) %*% t(J_sw)),
+                 tolerance = 1e-10, label = paste("conLM eq", tp))
+  }
+  z <- restriktor(fit, constraints = "x1 == x2", se = "standard",
+                  mix_weights = "none")
+  expect_equal(unname(summary(z)$V),
+               unname(J_sw %*% vcov(fit_red) %*% t(J_sw)),
+               tolerance = 1e-10)
+})
+
+test_that("conLM: gewogen lm (WLS) geeft correcte standard en HC standaardfouten", {
+  set.seed(99)
+  w_sw <- runif(n_sw, 0.2, 3)
+  fit  <- lm(y ~ x1 + x2 + x3, data = df_sw, weights = w_sw)
+  z <- restriktor(fit, constraints = "x1 > -100", se = "standard",
+                  mix_weights = "none")
+  expect_equal(unname(summary(z)$coefficients[, "Std. Error"]),
+               unname(summary(fit)$coefficients[, "Std. Error"]),
+               tolerance = 1e-10)
+  for (tp in c("HC0", "HC3")) {
+    z <- restriktor(fit, constraints = "x1 > -100", se = tp,
+                    mix_weights = "none")
+    expect_equal(unname(summary(z)$V), unname(sandwich::vcovHC(fit, type = tp)),
+                 tolerance = 1e-10, label = paste("conLM WLS", tp))
+  }
+})
+
+test_that("conLM: nulgewicht geeft geen NaN in HC2/HC3 standaardfouten", {
+  set.seed(99)
+  w0 <- runif(n_sw, 0.2, 3); w0[1] <- 0
+  fit <- lm(y ~ x1 + x2 + x3, data = df_sw, weights = w0)
+  z <- restriktor(fit, constraints = "x1 > -100", se = "HC3",
+                  mix_weights = "none")
+  expect_true(all(is.finite(summary(z)$coefficients[, "Std. Error"])))
+})
+
+# -----------------------------------------------------------------------------
+# conGLM
+# -----------------------------------------------------------------------------
+
+test_that("conGLM poisson: inactieve restricties reproduceren vcovHC exact", {
+  set.seed(42)
+  yp  <- rpois(n_sw, exp(0.3 + 0.4 * x1_sw + 0.5 * x2_sw - 0.2 * x3_sw))
+  fit <- glm(yp ~ x1 + x2 + x3, data = df_sw, family = poisson)
+  for (tp in hc_types_sw) {
+    z <- restriktor(fit, constraints = "x1 > -100", se = tp,
+                    mix_weights = "none")
+    expect_equal(unname(summary(z)$V), unname(sandwich::vcovHC(fit, type = tp)),
+                 tolerance = 1e-10, label = paste("conGLM poisson", tp))
+  }
+})
+
+test_that("conGLM gaussian (dispersie != 1): inactief reproduceert vcovHC exact", {
+  fit <- glm(y ~ x1 + x2 + x3, data = df_sw, family = gaussian)
+  for (tp in c("const", "HC0", "HC3")) {
+    z <- restriktor(fit, constraints = "x1 > -100", se = tp,
+                    mix_weights = "none")
+    expect_equal(unname(summary(z)$V), unname(sandwich::vcovHC(fit, type = tp)),
+                 tolerance = 1e-10, label = paste("conGLM gaussian", tp))
+  }
+})
+
+test_that("conGLM poisson: equality constraint == geherparametriseerd model", {
+  set.seed(42)
+  yp      <- rpois(n_sw, exp(0.3 + 0.4 * x1_sw + 0.5 * x2_sw - 0.2 * x3_sw))
+  fit     <- glm(yp ~ x1 + x2 + x3, data = df_sw, family = poisson)
+  fit_red <- glm(yp ~ I(x1 + x2) + x3, data = df_sw, family = poisson)
+  z <- restriktor(fit, constraints = "x1 == x2", se = "HC0",
+                  mix_weights = "none")
+  # iteratieve fit: iets ruimere tolerantie
+  expect_equal(unname(summary(z)$V),
+               unname(J_sw %*% sandwich::vcovHC(fit_red, type = "HC0") %*% t(J_sw)),
+               tolerance = 1e-4)
+})
+
+# -----------------------------------------------------------------------------
+# conRLM
+# -----------------------------------------------------------------------------
+
+test_that("conRLM: inactieve restricties reproduceren vcovHC exact (const/HC0/HC1)", {
+  set.seed(7)
+  yr <- 1 + 0.5 * x1_sw + 0.6 * x2_sw - 0.3 * x3_sw + rnorm(n_sw)
+  yr[1:5] <- yr[1:5] + 8  # outliers, door bisquare volledig neergewogen
+  df_r <- cbind(df_sw, yr = yr)
+  fit <- MASS::rlm(yr ~ x1 + x2 + x3, data = df_r, method = "MM")
+  # "const" dekt de terugval op modelresiduen bij estfun-rijen die exact 0 zijn
+  for (tp in c("const", "HC0", "HC1")) {
+    z <- restriktor(fit, constraints = "x1 > -100", se = tp,
+                    mix_weights = "none")
+    expect_equal(unname(summary(z)$V), unname(sandwich::vcovHC(fit, type = tp)),
+                 tolerance = 1e-8, label = paste("conRLM", tp))
+  }
+})
+
+test_that("conRLM: HC2 t/m HC5 draaien zonder error (regressie: x$wgt in meatHC)", {
+  set.seed(7)
+  yr <- 1 + 0.5 * x1_sw + 0.6 * x2_sw - 0.3 * x3_sw + rnorm(n_sw)
+  yr[1:5] <- yr[1:5] + 8
+  df_r <- cbind(df_sw, yr = yr)
+  fit <- MASS::rlm(yr ~ x1 + x2 + x3, data = df_r, method = "MM")
+  for (tp in c("HC2", "HC3", "HC4", "HC4m", "HC5")) {
+    z <- restriktor(fit, constraints = "x1 > -100", se = tp,
+                    mix_weights = "none")
+    s <- summary(z)
+    expect_true(all(is.finite(s$coefficients[, "Std. Error"])),
+                label = paste("conRLM", tp))
+  }
+})
+
+test_that("conRLM: equality constraint geeft eindige HC standaardfouten", {
+  set.seed(7)
+  yr <- 1 + 0.5 * x1_sw + 0.6 * x2_sw - 0.3 * x3_sw + rnorm(n_sw)
+  yr[1:5] <- yr[1:5] + 8
+  df_r <- cbind(df_sw, yr = yr)
+  fit <- MASS::rlm(yr ~ x1 + x2 + x3, data = df_r, method = "MM")
+  for (tp in c("HC0", "HC3")) {
+    z <- restriktor(fit, constraints = "x1 == x2", se = tp,
+                    mix_weights = "none")
+    s <- summary(z)
+    expect_true(all(is.finite(s$coefficients[, "Std. Error"])))
+    # onder x1 == x2 zijn de standaardfouten van x1 en x2 gelijk
+    expect_equal(unname(s$coefficients["x1", "Std. Error"]),
+                 unname(s$coefficients["x2", "Std. Error"]), tolerance = 1e-10)
+  }
+})


### PR DESCRIPTION
Bug fixes:
- meatHC: use x$wgt instead of x$w for conRLM hat values. x$w was an ambiguous partial match (wresid/weights/wgt/wt.bar) returning NULL, so se = "HC2".."HC5" always failed for conRLM objects.
- conLM: build the information matrix from the weighted model matrix (X'WX instead of X'X) so that both se = "standard" and the HC sandwich estimators are correct for weighted least squares.
- conRLM: estfun/bread now use the restricted scale estimate (x$scale) instead of the unrestricted x$model.org$s; identical when no restrictions are violated.

Alignment with sandwich 3.1-0:
- meatHC: for type = "const", fall back to the model residuals when estimating-function rows are exactly zero (e.g. observations fully downweighted by the bisquare psi in conRLM), mirroring the current sandwich::meatHC behaviour.
- estfun/bread/sandwich: add na.action handling as in sandwich 3.1-0.
- meatHC: compute hat values as rowSums(Q^2) directly; observations with zero weight now simply get a zero hat value, replacing the 1e-08 replacement hack and its unreachable warning.
- meatHC: index equality rows with seq_len(x$neq) and drop = FALSE instead of the fragile 0:x$neq indexing.

Add regression tests comparing against sandwich::vcovHC() for inactive restrictions (exact match, all HC types, conLM/conGLM/conRLM) and against the reparametrized model for equality constraints; add sandwich to Suggests.


Claude-Session: https://claude.ai/code/session_013y5V9kLqJZGejcpYAWorAk