### PR TITLE
Fix robust SE bugs and align con_sandwich.R with sandwich 3.1-0

### DIFF
--- a/R/con_sandwich.R
+++ b/R/con_sandwich.R
@@ -163,7 +163,19 @@ meatHC <- function(x,
       rW <- rep(1, n)
     }
 
-    QR <- qr.default(rW * X)
+    Xh <- rW * X
+    # under equality constraints the fitted values live in the column space
+    # of X %*% N, with N a basis for the null space of the equality rows;
+    # the hat values are therefore based on that reduced space. inequality
+    # constraints are not counted, consistent with the df correction above.
+    if (x$neq > 0L) {
+      Aeq <- x$constraints[seq_len(x$neq), , drop = FALSE]
+      QRt <- qr(t(Aeq))
+      N <- qr.Q(QRt, complete = TRUE)[, -seq_len(QRt$rank), drop = FALSE]
+      Xh <- Xh %*% N
+    }
+
+    QR <- qr.default(Xh)
     Q <- qr.qy(QR, diag(1, nrow = nrow(QR$qr), ncol = QR$rank))
     # diagonal of the hat matrix; observations with a zero weight simply get
     # a zero hat value.

--- a/tests/testthat/test-con_sandwich.R
+++ b/tests/testthat/test-con_sandwich.R
@@ -43,7 +43,8 @@ test_that("conLM: inactieve restricties reproduceren sandwich::vcovHC exact", {
 test_that("conLM: equality constraint == geherparametriseerd model", {
   fit     <- lm(y ~ x1 + x2 + x3, data = df_sw)
   fit_red <- lm(y ~ I(x1 + x2) + x3, data = df_sw)
-  for (tp in c("const", "HC0", "HC1")) {
+  # HC2/HC3 dekken ook de hatvalues in de gereduceerde kolomruimte (X %*% N)
+  for (tp in c("const", "HC0", "HC1", "HC2", "HC3")) {
     z <- restriktor(fit, constraints = "x1 == x2", se = tp, mix_weights = "none")
     expect_equal(unname(summary(z)$V),
                  unname(J_sw %*% sandwich::vcovHC(fit_red, type = tp) %*% t(J_sw)),


### PR DESCRIPTION
## Samenvatting

Herschrijft `con_sandwich.R` zodat de adaptatie weer aansluit bij het huidige sandwich-package (3.1-0), en repareert drie bugs in de robuuste standaardfouten. Gevalideerd tegen twee exacte referenties: bij **inactieve restricties** reproduceren alle HC-types `sandwich::vcovHC()` op machine-precisie, en bij **equality constraints** (`x1 == x2`) matchen de resultaten exact het geherparametriseerde model `y ~ I(x1 + x2) + ...` via `J %*% vcovHC(reduced) %*% t(J)`.

## Bugfixes

- **conRLM + HC2 t/m HC5 crashte altijd** (`Error: non-numeric argument to mathematical function`). `meatHC` las `x$w`, maar het conRLM-object heeft `wresid`/`weights`/`wgt`/`wt.bar`; de ambigue partial match gaf `NULL`. Nu wordt `x$wgt` (de IWLS-robuustheidsgewichten) gebruikt.
- **Gewogen lm (WLS) gaf foute standaardfouten**, ook met `se = "standard"`: de informatiematrix in `conLM.R` was `X'X/s²` in plaats van `X'WX/s²` (in de test 23% afwijking in de SE's; HC0 152%). De informatie wordt nu uit de gewogen modelmatrix opgebouwd en `con_augmented_information()` ontvangt dezelfde gewogen X, zodat ook de Lagrange-multipliers kloppen. De puntschattingen waren al correct.
- **conRLM gebruikte de unrestricted scale** (`x$model.org$s`) in `estfun`/`bread`, terwijl `conRLM_fit` de scale onder de restricties herschat (`x$scale`). Identiek wanneer geen restricties geschonden worden.

## Aansluiting bij sandwich 3.1-0

- `meatHC` valt bij `type = "const"` terug op de modelresiduen wanneer estfun-rijen exact nul zijn (observaties die bisquare volledig neerweegt), zoals de huidige `sandwich::meatHC`. conRLM + `const` matcht daarmee nu exact `vcovHC(rlm, "const")` (voorheen 86% afwijking).
- `na.action`-afhandeling toegevoegd in `sandwich()`, `bread` en `estfun`, conform 3.1-0.
- Hatvalues vereenvoudigd tot `rowSums(Q^2)`: nulgewichten krijgen vanzelf hatvalue 0, waardoor de 1e-08-vervangingshack en de (onbereikbare) warning konden vervallen. De QR-route zelf blijft nodig omdat `hatvalues()` niet op restricted objecten werkt.
- Fragiele indexering `x$constraints[0:x$neq, ]` vervangen door `seq_len(x$neq)` met `drop = FALSE`; `match.arg(type)` onvoorwaardelijk bovenaan.

## Verbetering: hatvalues onder equality constraints

Voor HC2–HC5 worden de hatvalues nu berekend uit `X %*% N`, met `N` een basis voor de nulruimte van de equality-rijen, zodat de leverage de restricted fit weerspiegelt. Onder `x1 == x2` matchen HC2/HC3 daarmee exact het geherparametriseerde model (voorheen 2–5% afwijking). Inequality constraints tellen niet mee, consistent met de df-correctie. Zonder equality constraints verandert er niets.

## Tests

- Nieuw: `tests/testthat/test-con_sandwich.R` (42 assertions) — exacte `vcovHC`-equivalentie voor alle acht HC-types (conLM, conGLM poisson/gaussian, conRLM incl. volledig neergewogen outliers), de herparametrisatie-referentie voor equality constraints (lm en poisson-glm, incl. HC2/HC3), WLS-checks en regressietests voor de `x$wgt`-fix en nulgewichten. Skipt netjes zonder sandwich; `sandwich` toegevoegd aan `Suggests`.
- Volledige suite: **1033 passed, 0 failed** (zelfde 15 pre-existing warnings in test-goric.R als op master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013y5V9kLqJZGejcpYAWorAk

---
_Generated by [Claude Code](https://claude.ai/code/session_013y5V9kLqJZGejcpYAWorAk)_