### PR TITLE
Add HAC standard errors for restricted models (issue #8)

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -184,3 +184,15 @@ S3method(print, goric_ICw)
 S3method(print, benchmark)
 S3method(plot, benchmark)
 S3method(print, benchmark_plot)
+
+# register the bread() and estfun() methods for the generics of the
+# (suggested) sandwich package, so that e.g. sandwich::vcovHAC(),
+# sandwich::kernHAC(), sandwich::NeweyWest() and sandwich::vcovCL() can be
+# applied directly to restricted models. the registration takes effect once
+# the sandwich package is loaded (delayed registration).
+S3method(sandwich::bread, conLM)
+S3method(sandwich::bread, conRLM)
+S3method(sandwich::bread, conGLM)
+S3method(sandwich::estfun, conLM)
+S3method(sandwich::estfun, conRLM)
+S3method(sandwich::estfun, conGLM)

--- a/R/conGLM.R
+++ b/R/conGLM.R
@@ -14,8 +14,14 @@ conGLM.glm <- function(object, constraints = NULL, se = "standard",
     se <- "boot.model.based"
   }
   if (!(se %in% c("none","standard","const","boot.model.based","boot.standard",
-                  "HC","HC0","HC1","HC2","HC3","HC4","HC4m","HC5"))) {
+                  "HC","HC0","HC1","HC2","HC3","HC4","HC4m","HC5",
+                  "HAC","kernHAC","NeweyWest"))) {
     stop("restriktor ERROR: standard error method ", sQuote(se), " unknown.")
+  }
+  if (se %in% c("HAC","kernHAC","NeweyWest") &&
+      !requireNamespace("sandwich", quietly = TRUE)) {
+    stop("restriktor ERROR: se = ", sQuote(se),
+         " requires the 'sandwich' package. Please install it.", call. = FALSE)
   }
   # check method to compute chi-square-bar weights
   if (!(mix_weights %in% c("pmvnorm", "boot", "none"))) {

--- a/R/conLM.R
+++ b/R/conLM.R
@@ -15,8 +15,14 @@ conLM.lm <- function(object, constraints = NULL, se = "standard",
     se <- "boot.model.based"
   }
   if (!(se %in% c("none","standard","const","boot.model.based","boot.standard",
-                  "HC","HC0","HC1","HC2","HC3","HC4","HC4m","HC5"))) {
+                  "HC","HC0","HC1","HC2","HC3","HC4","HC4m","HC5",
+                  "HAC","kernHAC","NeweyWest"))) {
     stop("restriktor ERROR: standard error method ", sQuote(se), " unknown.", call. = FALSE)
+  }
+  if (se %in% c("HAC","kernHAC","NeweyWest") &&
+      !requireNamespace("sandwich", quietly = TRUE)) {
+    stop("restriktor ERROR: se = ", sQuote(se),
+         " requires the 'sandwich' package. Please install it.", call. = FALSE)
   }
   # check method to compute chi-square-bar weights
   if (!(mix_weights %in% c("pmvnorm", "boot", "none"))) {

--- a/R/conRLM.R
+++ b/R/conRLM.R
@@ -15,8 +15,14 @@ conRLM.rlm <- function(object, constraints = NULL, se = "standard",
     se <- "boot.model.based"
   }
   if (!(se %in% c("none","standard","const","boot.model.based","boot.standard","HC","HC0",
-                  "HC1","HC2","HC3","HC4","HC4m","HC5"))) {
+                  "HC1","HC2","HC3","HC4","HC4m","HC5",
+                  "HAC","kernHAC","NeweyWest"))) {
     stop("restriktor ERROR: standard error method ", sQuote(se), " unknown.")
+  }
+  if (se %in% c("HAC","kernHAC","NeweyWest") &&
+      !requireNamespace("sandwich", quietly = TRUE)) {
+    stop("restriktor ERROR: se = ", sQuote(se),
+         " requires the 'sandwich' package. Please install it.", call. = FALSE)
   }
   # check method to compute chi-square-bar weights
   if (!(mix_weights %in% c("pmvnorm", "boot", "none"))) {

--- a/R/con_sandwich.R
+++ b/R/con_sandwich.R
@@ -128,6 +128,62 @@ estfun.conGLM <- function(x, ...) {
 }
 
 
+# HAC (heteroskedasticity and autocorrelation consistent) covariance matrix
+# for restricted models. the meat is computed by the sandwich package from the
+# empirical estimating functions of the restricted fit (the estfun methods
+# above are registered for the sandwich generics in the NAMESPACE); the bread
+# is the inverted augmented information matrix, so that the (in)equality
+# restrictions are taken into account. without active restrictions the results
+# are identical to sandwich::vcovHAC(), sandwich::kernHAC() and
+# sandwich::NeweyWest(), respectively.
+con_vcovHAC <- function(x, type = c("HAC", "kernHAC", "NeweyWest"), ...) {
+  type <- match.arg(type)
+  if (!requireNamespace("sandwich", quietly = TRUE)) {
+    stop("restriktor ERROR: se = ", sQuote(type),
+         " requires the 'sandwich' package. Please install it.", call. = FALSE)
+  }
+  fun <- switch(type,
+                "HAC"       = sandwich::vcovHAC,
+                "kernHAC"   = sandwich::kernHAC,
+                "NeweyWest" = sandwich::NeweyWest)
+
+  # sandwich's finite-sample adjustment n / (n - k) counts all k = p columns
+  # of the estimating function; under equality constraints only
+  # k = p - rank(Aeq) parameters are free (cf. the df correction in meatHC).
+  # hence the adjustment is applied here instead of inside sandwich. the
+  # defaults follow sandwich: adjust = TRUE for vcovHAC/kernHAC and
+  # adjust = FALSE for NeweyWest.
+  ldots <- list(...)
+  adjust <- if (is.null(ldots$adjust)) {
+    type %in% c("HAC", "kernHAC")
+  } else {
+    isTRUE(ldots$adjust)
+  }
+  ldots$adjust <- FALSE
+  # only pass arguments the sandwich function understands; NeweyWest() has no
+  # '...' and summary.restriktor() passes along unrelated arguments.
+  pnames <- switch(type,
+    "HAC"       = c("order.by", "prewhite", "weights", "adjust", "diagnostics",
+                    "ar.method", "data", "bw", "kernel", "approx", "tol", "verbose"),
+    "kernHAC"   = c("order.by", "prewhite", "bw", "kernel", "approx", "adjust",
+                    "diagnostics", "ar.method", "tol", "data", "verbose"),
+    "NeweyWest" = c("lag", "order.by", "prewhite", "adjust", "diagnostics",
+                    "ar.method", "data", "verbose"))
+  ldots <- ldots[names(ldots) %in% pnames]
+
+  rval <- do.call(fun, c(list(x), ldots))
+
+  if (adjust) {
+    n <- NROW(estfun(x))
+    p <- NCOL(x$constraints)
+    k <- p - qr(x$constraints[seq_len(x$neq), , drop = FALSE])$rank
+    rval <- n / (n - k) * rval
+  }
+
+  return(rval)
+}
+
+
 meatHC <- function(x,
                    type = c("HC3", "const", "HC", "HC0", "HC1", "HC2", "HC4", "HC4m", "HC5"),
                    omega = NULL) {

--- a/R/restriktor_print_summary.R
+++ b/R/restriktor_print_summary.R
@@ -69,6 +69,9 @@ print.summary.restriktor <- function(x, digits = max(3, getOption("digits") - 2)
       se.type <- "standard"
     }
     cat("\nBootstrapped standard errors:", se.type ,"\n")
+  } else if (se.type %in% c("HAC", "kernHAC", "NeweyWest")) {
+    cat("\nHeteroskedasticity and autocorrelation robust standard errors:",
+        se.type, "\n")
   } else {
     cat("\nHeteroskedastic robust standard errors:", se.type ,"\n")
   }

--- a/R/restriktor_summary.R
+++ b/R/restriktor_summary.R
@@ -54,9 +54,15 @@ summary.restriktor <- function(object, bootCIs = TRUE, bty = "perc",
     if (se.type == "standard") {
       V <- attr(z$information, "inverted")
       se <- sqrt(diag(V))
+    } else if (se.type %in% c("HAC", "kernHAC", "NeweyWest")) {
+      # heteroskedasticity and autocorrelation consistent (HAC) covariance
+      # matrix; additional arguments (e.g., prewhite, bw, kernel, lag) are
+      # passed on to the sandwich package.
+      V <- do.call(con_vcovHAC, c(list(z, type = se.type), ldots))
+      se <- sqrt(diag(V))
     } else {
-      V <- sandwich(z, 
-                    bread. = bread(z), 
+      V <- sandwich(z,
+                    bread. = bread(z),
                     meat.  = meatHC(z, type = se.type))
       se <- sqrt(diag(V))
     }

--- a/man/restriktor.Rd
+++ b/man/restriktor.Rd
@@ -66,9 +66,22 @@ restriktor(object, constraints = NULL, \dots)
   If "\code{HC0}" or just "\code{HC}", heteroskedastic robust standard 
   errors are computed (a.k.a Huber White). The options "\code{HC1}", 
   "\code{HC2}", "\code{HC3}", "\code{HC4}", "\code{HC4m}", and 
-  "\code{HC5}" are refinements of "\code{HC0}". For more details about 
-  heteroskedastic robust standard errors see the \pkg{sandwich} 
-  package. If "\code{boot.standard}", bootstrapped standard 
+  "\code{HC5}" are refinements of "\code{HC0}". For more details about
+  heteroskedastic robust standard errors see the \pkg{sandwich}
+  package. If "\code{HAC}", "\code{kernHAC}" or "\code{NeweyWest}",
+  heteroskedasticity and autocorrelation consistent (HAC) standard
+  errors are computed (requires the \pkg{sandwich} package). The meat
+  is based on the estimating functions of the restricted model and the
+  bread on the inverted augmented information matrix, so that the
+  restrictions are taken into account; "\code{HAC}" corresponds to
+  \code{sandwich::vcovHAC}, "\code{kernHAC}" to \code{sandwich::kernHAC}
+  and "\code{NeweyWest}" to \code{sandwich::NeweyWest}. Additional
+  arguments (e.g., \code{prewhite}, \code{bw}, \code{kernel},
+  \code{lag}) can be passed via \code{summary()}, e.g.,
+  \code{summary(fit.restr, bw = 2)}. Alternatively, these
+  \pkg{sandwich} functions (and, e.g., \code{sandwich::vcovCL}) can be
+  applied directly to the restricted model object, e.g.,
+  \code{sandwich::vcovHAC(fit.restr)}. If "\code{boot.standard}", bootstrapped standard
   errors are computed using standard bootstrapping. If "\code{boot.model.based}" 
   or "\code{boot.residual}", bootstrapped standard errors are computed 
   using model-based bootstrapping. If "\code{none}", no standard errors

--- a/tests/testthat/test-con_sandwich.R
+++ b/tests/testthat/test-con_sandwich.R
@@ -156,6 +156,121 @@ test_that("conRLM: HC2 t/m HC5 draaien zonder error (regressie: x$wgt in meatHC)
   }
 })
 
+# -----------------------------------------------------------------------------
+# HAC: vcovHAC / kernHAC / NeweyWest (issue #8)
+#
+# Exacte referenties, analoog aan de HC-tests hierboven:
+#  1. inactieve restricties: se = "HAC"/"kernHAC"/"NeweyWest" moet
+#     sandwich::vcovHAC/kernHAC/NeweyWest op het originele model exact
+#     reproduceren, en de sandwich-generics moeten ook direct op het
+#     restriktor-object werken.
+#  2. equality constraint x1 == x2: identiek aan het geherparametriseerde
+#     model, mits de datagedreven stappen (bandbreedte, prewhitening) worden
+#     vastgezet, want die zien 4 vs. 3 estfun-kolommen.
+# -----------------------------------------------------------------------------
+
+# AR(1) fouten zodat de autocorrelatie-correctie er echt toe doet
+set.seed(321)
+e_ar  <- as.numeric(stats::arima.sim(list(ar = 0.6), n = n_sw))
+y_ar  <- 1 + 0.5 * x1_sw + 0.6 * x2_sw - 0.3 * x3_sw + e_ar
+df_ar <- data.frame(y = y_ar, x1 = x1_sw, x2 = x2_sw, x3 = x3_sw)
+
+test_that("conLM: inactieve restricties reproduceren vcovHAC/kernHAC/NeweyWest exact", {
+  fit <- lm(y ~ x1 + x2 + x3, data = df_ar)
+  ref <- list(HAC       = sandwich::vcovHAC(fit),
+              kernHAC   = sandwich::kernHAC(fit),
+              NeweyWest = sandwich::NeweyWest(fit))
+  for (tp in names(ref)) {
+    z <- restriktor(fit, constraints = "x1 > -100; x2 > -100", se = tp,
+                    mix_weights = "none")
+    expect_equal(unname(summary(z)$V), unname(ref[[tp]]),
+                 tolerance = 1e-10, label = paste("conLM", tp))
+  }
+})
+
+test_that("sandwich generics werken direct op restriktor-objecten (conLM)", {
+  fit <- lm(y ~ x1 + x2 + x3, data = df_ar)
+  z <- restriktor(fit, constraints = "x1 > -100", se = "standard",
+                  mix_weights = "none")
+  expect_equal(unname(sandwich::estfun(z)), unname(sandwich::estfun(fit)),
+               tolerance = 1e-10)
+  expect_equal(unname(sandwich::bread(z)), unname(sandwich::bread(fit)),
+               tolerance = 1e-10)
+  expect_equal(unname(sandwich::vcovHAC(z)), unname(sandwich::vcovHAC(fit)),
+               tolerance = 1e-10)
+  expect_equal(unname(sandwich::kernHAC(z)), unname(sandwich::kernHAC(fit)),
+               tolerance = 1e-10)
+  expect_equal(unname(sandwich::NeweyWest(z)), unname(sandwich::NeweyWest(fit)),
+               tolerance = 1e-10)
+})
+
+test_that("conLM: equality constraint == geherparametriseerd model (HAC)", {
+  fit     <- lm(y ~ x1 + x2 + x3, data = df_ar)
+  fit_red <- lm(y ~ I(x1 + x2) + x3, data = df_ar)
+
+  # kernHAC met vaste bandbreedte en zonder prewhitening
+  z <- restriktor(fit, constraints = "x1 == x2", se = "kernHAC",
+                  mix_weights = "none")
+  expect_equal(unname(summary(z, bw = 2, prewhite = FALSE)$V),
+               unname(J_sw %*% sandwich::kernHAC(fit_red, bw = 2, prewhite = FALSE) %*% t(J_sw)),
+               tolerance = 1e-10)
+
+  # vcovHAC met vaste gewichten
+  w_hac <- c(1, 0.7, 0.4, 0.1)
+  z <- restriktor(fit, constraints = "x1 == x2", se = "HAC",
+                  mix_weights = "none")
+  expect_equal(unname(summary(z, weights = w_hac)$V),
+               unname(J_sw %*% sandwich::vcovHAC(fit_red, weights = w_hac) %*% t(J_sw)),
+               tolerance = 1e-10)
+
+  # NeweyWest met vaste lag en zonder prewhitening (adjust = FALSE default)
+  z <- restriktor(fit, constraints = "x1 == x2", se = "NeweyWest",
+                  mix_weights = "none")
+  expect_equal(unname(summary(z, lag = 3, prewhite = FALSE)$V),
+               unname(J_sw %*% sandwich::NeweyWest(fit_red, lag = 3, prewhite = FALSE) %*% t(J_sw)),
+               tolerance = 1e-10)
+})
+
+test_that("conGLM poisson: inactieve restricties reproduceren vcovHAC exact", {
+  set.seed(42)
+  yp  <- rpois(n_sw, exp(0.3 + 0.4 * x1_sw + 0.5 * x2_sw - 0.2 * x3_sw))
+  fit <- glm(yp ~ x1 + x2 + x3, data = df_sw, family = poisson)
+  z <- restriktor(fit, constraints = "x1 > -100", se = "HAC",
+                  mix_weights = "none")
+  expect_equal(unname(summary(z)$V), unname(sandwich::vcovHAC(fit)),
+               tolerance = 1e-10)
+  z <- restriktor(fit, constraints = "x1 > -100", se = "NeweyWest",
+                  mix_weights = "none")
+  expect_equal(unname(summary(z)$V), unname(sandwich::NeweyWest(fit)),
+               tolerance = 1e-10)
+})
+
+test_that("conRLM: inactieve restricties reproduceren vcovHAC exact", {
+  set.seed(7)
+  yr <- 1 + 0.5 * x1_sw + 0.6 * x2_sw - 0.3 * x3_sw + rnorm(n_sw)
+  yr[1:5] <- yr[1:5] + 8
+  df_r <- cbind(df_sw, yr = yr)
+  fit <- MASS::rlm(yr ~ x1 + x2 + x3, data = df_r, method = "MM")
+  z <- restriktor(fit, constraints = "x1 > -100", se = "HAC",
+                  mix_weights = "none")
+  expect_equal(unname(summary(z)$V), unname(sandwich::vcovHAC(fit)),
+               tolerance = 1e-8)
+})
+
+test_that("conLM: equality constraint geeft gelijke HAC standaardfouten voor x1 en x2", {
+  fit <- lm(y ~ x1 + x2 + x3, data = df_ar)
+  for (tp in c("HAC", "kernHAC", "NeweyWest")) {
+    z <- restriktor(fit, constraints = "x1 == x2", se = tp,
+                    mix_weights = "none")
+    s <- summary(z)
+    expect_true(all(is.finite(s$coefficients[, "Std. Error"])),
+                label = paste("conLM eq", tp))
+    expect_equal(unname(s$coefficients["x1", "Std. Error"]),
+                 unname(s$coefficients["x2", "Std. Error"]),
+                 tolerance = 1e-10, label = paste("conLM eq", tp))
+  }
+})
+
 test_that("conRLM: equality constraint geeft eindige HC standaardfouten", {
   set.seed(7)
   yr <- 1 + 0.5 * x1_sw + 0.6 * x2_sw - 0.3 * x3_sw + rnorm(n_sw)


### PR DESCRIPTION
Restricted models could not be combined with autocorrelation-robust covariance estimators: se only offered HC-type estimators and the iid bootstrap, and sandwich::vcovHAC()/kernHAC()/NeweyWest() could not be applied to a restriktor object because no bread() and estfun() methods were registered for the sandwich generics.

Two complementary routes are now available:

- restriktor(..., se = "HAC"/"kernHAC"/"NeweyWest") computes HAC standard errors in summary(); the meat is computed by the sandwich package from the estimating functions of the restricted fit and the bread is the inverted augmented information matrix, so the restrictions are taken into account. Extra arguments (prewhite, bw, kernel, lag, ...) pass through summary(). The finite-sample adjustment n/(n-k) counts only the k = p - rank(Aeq) free parameters, consistent with the df correction in meatHC().

- the existing bread() and estfun() methods for conLM/conRLM/conGLM are registered (delayed) for the sandwich generics, so vcovHAC(), kernHAC(), NeweyWest(), weave() and vcovCL() from the sandwich package can also be applied directly to the restricted model object.

Without active restrictions the results are identical to applying the sandwich estimators to the unrestricted model; under equality restrictions they equal the reparametrized (reduced-rank) model mapped back, which is what issue #8 asks for. Both properties are covered by new tests against exact references.


Claude-Session: https://claude.ai/code/session_01Y57THnRvW9H2QH9uSFnsnb